### PR TITLE
Fix identifier query for field 024 [MELKEHITYS-1848]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@natlibfi/melinda-record-matching",
-	"version": "1.0.4",
+	"version": "1.0.5",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {

--- a/src/candidate-search/query-list/bib.js
+++ b/src/candidate-search/query-list/bib.js
@@ -97,41 +97,23 @@ export function bibStandardIdentifiers(record) {
   return pairs.map(([a, b]) => b ? `dc.identifier=${a} or dc.identifier=${b}` : `dc.identifier=${a}`);
 
   function toIdentifiers({tag, subfields}) {
+    const issnIsbnReqExp = (/^[A-Za-z0-9-]+$/u);
 
     if (tag === '022') {
       return subfields
-        .filter(createFilterIsbnIssn('a', 'z', 'y'))
+        .filter(sub => ['a', 'z', 'y'].includes(sub.code) && issnIsbnReqExp.test(sub.value) && sub.value !== undefined)
         .map(({value}) => value);
     }
 
     if (tag === '020') {
       return subfields
-        .filter(createFilterIsbnIssn('a', 'z'))
+        .filter(sub => ['a', 'z'].includes(sub.code) && issnIsbnReqExp.test(sub.value) && sub.value !== undefined)
         .map(({value}) => value);
     }
 
     return subfields
-      .filter(createFilter('a', 'z'))
+      .filter(sub => ['a', 'z'].includes(sub.code) && sub.value !== undefined)
       .map(({value}) => value);
-
-    function createFilterIsbnIssn(...codes) {
-      return ({code, value}) => {
-
-        if (codes.includes(code)) {
-          // Standard identifiers ISBN and ISSN should only contain letters, numbers and dashes
-          return value && (/^[A-Za-z0-9\-]+$/u).test(value); // eslint-disable-line no-useless-escape
-        }
-      };
-    }
-
-    function createFilter(...codes) {
-      return ({code, value}) => {
-
-        if (codes.includes(code)) {
-          return value;
-        }
-      };
-    }
   }
 
   function toPairs(results, identifier) {

--- a/src/candidate-search/query-list/bib.js
+++ b/src/candidate-search/query-list/bib.js
@@ -28,7 +28,8 @@
 */
 import createDebugLogger from 'debug';
 
-// bibHostComponents returns host id from the first subfield $w of first field f773
+// bibHostComponents returns host id from the first subfield $w of first field f773, see test-fixtures 04 and 05
+// bibHostComponents should search all 773 $ws for possible host id, but what should it do in case of multiple host ids?
 export function bibHostComponents(record) {
   const id = getHostId();
   return id ? [`melinda.partsofhost=${id}`] : [];

--- a/src/candidate-search/query-list/bib.js
+++ b/src/candidate-search/query-list/bib.js
@@ -36,6 +36,7 @@ export function bibHostComponents(record) {
     const [field] = record.get(/^773$/u);
 
     if (field) {
+
       const {value} = field.subfields.find(({code}) => code === 'w') || {};
 
       if (value && (/^\(FI-MELINDA\)/u).test(value)) {
@@ -53,6 +54,7 @@ export function bibTitle(record) {
   const title = getTitle();
 
   if (title) {
+
     const formatted = title
       .replace(/[^\w\s\p{Alphabetic}]/gu, '')
       .trim()
@@ -80,8 +82,8 @@ export function bibTitle(record) {
 // Aleph supports only two queries with or -operator (This is not true,)
 // eslint-disable-next-line max-statements
 export function bibStandardIdentifiers(record) {
-  const debug = createDebugLogger('@natlibfi/melinda-record-matching:candidate-search:query:bibStandardIdentifiers');
 
+  const debug = createDebugLogger('@natlibfi/melinda-record-matching:candidate-search:query:bibStandardIdentifiers');
   debug(`Creating queries for standard identifiers`);
 
   const fields = record.get(/^(?<def>020|022|024)$/u);
@@ -91,22 +93,26 @@ export function bibStandardIdentifiers(record) {
   return pairs.map(([a, b]) => b ? `dc.identifier=${a} or dc.identifier=${b}` : `dc.identifier=${a}`);
 
   function toIdentifiers({tag, subfields}) {
+
     if (tag === '022') {
       return subfields
         .filter(createFilterIsbnIssn('a', 'z', 'y'))
         .map(({value}) => value);
     }
+
     if (tag === '020') {
       return subfields
         .filter(createFilterIsbnIssn('a', 'z'))
         .map(({value}) => value);
     }
+
     return subfields
       .filter(createFilter('a', 'z'))
       .map(({value}) => value);
 
     function createFilterIsbnIssn(...codes) {
       return ({code, value}) => {
+
         if (codes.includes(code)) {
           // Standard identifiers ISBN and ISSN should only contain letters, numbers and dashes
           return value && (/^[A-Za-z0-9\-]+$/u).test(value); // eslint-disable-line no-useless-escape
@@ -115,6 +121,7 @@ export function bibStandardIdentifiers(record) {
     }
     function createFilter(...codes) {
       return ({code, value}) => {
+
         if (codes.includes(code)) {
           return value;
         }
@@ -127,6 +134,7 @@ export function bibStandardIdentifiers(record) {
     const [tail] = results.slice(-1);
 
     if (tail) {
+
       if (tail.length === 2) {
 
         return results.concat([[identifier]]);

--- a/src/candidate-search/query-list/bib.js
+++ b/src/candidate-search/query-list/bib.js
@@ -28,6 +28,7 @@
 */
 import createDebugLogger from 'debug';
 
+// bibHostComponents returns host id from the first subfield $w of first field f773
 export function bibHostComponents(record) {
   const id = getHostId();
   return id ? [`melinda.partsofhost=${id}`] : [];
@@ -45,7 +46,10 @@ export function bibHostComponents(record) {
       if (value && (/^\(FIN01\)/u).test(value)) {
         return value.replace(/^\(FIN01\)/u, '');
       }
+
+      return false;
     }
+    return false;
   }
 }
 
@@ -74,6 +78,7 @@ export function bibTitle(record) {
         .map(({value}) => value)
         .join('');
     }
+    return false;
   }
 }
 

--- a/src/candidate-search/query-list/bib.js
+++ b/src/candidate-search/query-list/bib.js
@@ -36,7 +36,6 @@ export function bibHostComponents(record) {
     const [field] = record.get(/^773$/u);
 
     if (field) {
-
       const {value} = field.subfields.find(({code}) => code === 'w') || {};
 
       if (value && (/^\(FI-MELINDA\)/u).test(value)) {
@@ -54,7 +53,6 @@ export function bibTitle(record) {
   const title = getTitle();
 
   if (title) {
-
     const formatted = title
       .replace(/[^\w\s\p{Alphabetic}]/gu, '')
       .trim()
@@ -119,6 +117,7 @@ export function bibStandardIdentifiers(record) {
         }
       };
     }
+
     function createFilter(...codes) {
       return ({code, value}) => {
 
@@ -134,9 +133,7 @@ export function bibStandardIdentifiers(record) {
     const [tail] = results.slice(-1);
 
     if (tail) {
-
       if (tail.length === 2) {
-
         return results.concat([[identifier]]);
       }
 

--- a/src/candidate-search/query-list/bib.spec.js
+++ b/src/candidate-search/query-list/bib.spec.js
@@ -38,9 +38,12 @@ generateTests({
   fixura: {
     reader: READERS.JSON
   },
-  callback: ({type, inputRecord, expectedQuery}) => {
+  callback: ({type, inputRecord, expectedQuery, enabled = true}) => {
     const generate = generators[type];
     const record = new MarcRecord(inputRecord, {subfieldValues: false});
+    if (!enabled) {
+      return;
+    }
     expect(generate(record)).to.eql(expectedQuery);
   }
 });

--- a/src/candidate-search/query-list/bib.spec.js
+++ b/src/candidate-search/query-list/bib.spec.js
@@ -41,9 +41,11 @@ generateTests({
   callback: ({type, inputRecord, expectedQuery, enabled = true}) => {
     const generate = generators[type];
     const record = new MarcRecord(inputRecord, {subfieldValues: false});
+
     if (!enabled) {
       return;
     }
+
     expect(generate(record)).to.eql(expectedQuery);
   }
 });

--- a/test-fixtures/candidate-search/query-list/bib/hostComponents/02/metadata.json
+++ b/test-fixtures/candidate-search/query-list/bib/hostComponents/02/metadata.json
@@ -1,5 +1,5 @@
 {
-  "description": "Should generate host record query (No 773)",
+  "description": "Should not generate host record query (No 773)",
   "type": "bibHostComponents",
   "expectedQuery": [],
   "inputRecord": {

--- a/test-fixtures/candidate-search/query-list/bib/hostComponents/04/metadata.json
+++ b/test-fixtures/candidate-search/query-list/bib/hostComponents/04/metadata.json
@@ -1,0 +1,34 @@
+{
+  "description": "DISABLED: Should generate host record query (several sf $w)",
+  "enabled": false,
+  "type": "bibHostComponents",
+  "expectedQuery": ["melinda.partsofhost=12345"],
+  "inputRecord": {
+    "leader": "02518cam a2200745zi 4500",
+    "fields": [
+      {
+        "tag": "001",
+        "value": "000019643"
+      },
+      {
+        "tag": "773",
+        "ind1": " ",
+        "ind2": " ",
+        "subfields": [
+          {
+            "code": "a",
+            "value": "foobar"
+          },
+          {
+            "code": "w",
+            "value": "(VIOLA)99912345"
+          },
+          {
+            "code": "w",
+            "value": "(FIN01)12345"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/test-fixtures/candidate-search/query-list/bib/hostComponents/05/metadata.json
+++ b/test-fixtures/candidate-search/query-list/bib/hostComponents/05/metadata.json
@@ -1,0 +1,45 @@
+{
+  "description": "DISABLED: Should generate host record query (several f773)",
+  "enabled": false,
+  "type": "bibHostComponents",
+  "expectedQuery": ["melinda.partsofhost=12345"],
+  "inputRecord": {
+    "leader": "02518cam a2200745zi 4500",
+    "fields": [
+      {
+        "tag": "001",
+        "value": "000019643"
+      },
+      {
+        "tag": "773",
+        "ind1": " ",
+        "ind2": " ",
+        "subfields": [
+          {
+            "code": "a",
+            "value": "foobar"
+          },
+          {
+            "code": "w",
+            "value": "(VIOLA)9999912345"
+          }
+        ]
+      },
+      {
+        "tag": "773",
+        "ind1": " ",
+        "ind2": " ",
+        "subfields": [
+          {
+            "code": "a",
+            "value": "foobar"
+          },
+          {
+            "code": "w",
+            "value": "(FIN01)12345"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/test-fixtures/candidate-search/query-list/bib/standardIdentifiers/01/metadata.json
+++ b/test-fixtures/candidate-search/query-list/bib/standardIdentifiers/01/metadata.json
@@ -1,5 +1,5 @@
 {
-  "description": "Should generate title query",
+  "description": "Should generate standard identifier query (ISBN)",
   "type": "bibStandardIdentifiers",
   "expectedQuery": [
     "dc.identifier=951-772-249-4 or dc.identifier=951-8915-60-1",

--- a/test-fixtures/candidate-search/query-list/bib/standardIdentifiers/03/metadata.json
+++ b/test-fixtures/candidate-search/query-list/bib/standardIdentifiers/03/metadata.json
@@ -1,7 +1,7 @@
 {
-  "description": "Should generate standard identifier query (ISSN)",
+  "description": "Should generate standard identifier query from f024 (URN)",
   "type": "bibStandardIdentifiers",
-  "expectedQuery": ["dc.identifier=2049-3630"],
+  "expectedQuery": ["dc.identifier=URN:NBN:fi-fe202002216161"],
   "inputRecord": {
     "leader": "02518cam a2200745zi 4500",
     "fields": [
@@ -10,13 +10,17 @@
         "value": "000019643"
       },
       {
-        "tag": "022",
-        "ind1": " ",
+        "tag": "024",
+        "ind1": "7",
         "ind2": " ",
         "subfields": [
           {
             "code": "a",
-            "value": "2049-3630"
+            "value": "URN:NBN:fi-fe202002216161"
+          },
+          {
+            "code": "2",
+            "value": "urn"
           }
         ]
       }

--- a/test-fixtures/candidate-search/query-list/bib/standardIdentifiers/04/metadata.json
+++ b/test-fixtures/candidate-search/query-list/bib/standardIdentifiers/04/metadata.json
@@ -1,7 +1,9 @@
 {
-  "description": "Should generate standard identifier query (ISSN)",
+  "description": "Should generate standard identifier query (ISBN, f020 with $a and $z)",
   "type": "bibStandardIdentifiers",
-  "expectedQuery": ["dc.identifier=2049-3630"],
+  "expectedQuery": [
+    "dc.identifier=951-772-249-4 or dc.identifier=951-772-249-X"
+  ],
   "inputRecord": {
     "leader": "02518cam a2200745zi 4500",
     "fields": [
@@ -10,13 +12,17 @@
         "value": "000019643"
       },
       {
-        "tag": "022",
+        "tag": "020",
         "ind1": " ",
         "ind2": " ",
         "subfields": [
           {
             "code": "a",
-            "value": "2049-3630"
+            "value": "951-772-249-4"
+          },
+          {
+            "code": "z",
+            "value": "951-772-249-X"
           }
         ]
       }

--- a/test-fixtures/candidate-search/query-list/bib/standardIdentifiers/05/metadata.json
+++ b/test-fixtures/candidate-search/query-list/bib/standardIdentifiers/05/metadata.json
@@ -1,0 +1,37 @@
+{
+  "description": "DISABLED: Should generate standard identifier query (ISBN, f020 with several subfields $z)",
+  "enabled": false,
+  "type": "bibStandardIdentifiers",
+  "expectedQuery": [
+    "dc.identifier=951-772-249-4 or dc.identifier=951-772-249-X",
+    "dc.identifier=9999-772-249-4"
+  ],
+  "inputRecord": {
+    "leader": "02518cam a2200745zi 4500",
+    "fields": [
+      {
+        "tag": "001",
+        "value": "000019643"
+      },
+      {
+        "tag": "020",
+        "ind1": " ",
+        "ind2": " ",
+        "subfields": [
+          {
+            "code": "a",
+            "value": "951-772-249-4"
+          },
+          {
+            "code": "z",
+            "value": "951-772-249-X"
+          },
+          {
+            "code": "z",
+            "value": "9999-772-249-4"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/test-fixtures/candidate-search/query-list/bib/standardIdentifiers/06/metadata.json
+++ b/test-fixtures/candidate-search/query-list/bib/standardIdentifiers/06/metadata.json
@@ -1,5 +1,6 @@
 {
-  "description": "Should generate standard identifier query (ISSN)",
+  "description": "DISABLED: Should not generate 'undefined' standard identifier query (ISSN with colon)",
+  "enabled": false,
   "type": "bibStandardIdentifiers",
   "expectedQuery": ["dc.identifier=2049-3630"],
   "inputRecord": {
@@ -16,7 +17,7 @@
         "subfields": [
           {
             "code": "a",
-            "value": "2049-3630"
+            "value": "2049:3630"
           }
         ]
       }

--- a/test-fixtures/candidate-search/query-list/bib/standardIdentifiers/07/metadata.json
+++ b/test-fixtures/candidate-search/query-list/bib/standardIdentifiers/07/metadata.json
@@ -1,0 +1,26 @@
+{
+  "description": "DISABLED: Should not generate standard identifier query from identifier value including not allowed characters (ISSN)",
+  "enabled": false,
+  "type": "bibStandardIdentifiers",
+  "expectedQuery": [],
+  "inputRecord": {
+    "leader": "02518cam a2200745zi 4500",
+    "fields": [
+      {
+        "tag": "001",
+        "value": "000019643"
+      },
+      {
+        "tag": "022",
+        "ind1": " ",
+        "ind2": " ",
+        "subfields": [
+          {
+            "code": "a",
+            "value": "  :204 9-3630??"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Valid identifiers in field 024 can contain also other characters than letters, numbers and dashes.

Identifier value check (identifier contains only letters, numbers and dashes) is now only made for identifiers from fields 020 (ISBN) and 022 (ISSN). 
