### PR TITLE
Fix broken queries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@natlibfi/melinda-record-matching",
-	"version": "1.0.5",
+	"version": "1.0.6-alpha.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/melinda-record-matching",
-			"version": "1.0.3",
+			"version": "1.0.6-alpha.1",
 			"license": "LGPL-3.0+",
 			"dependencies": {
 				"@natlibfi/marc-record": "^6.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@natlibfi/melinda-record-matching",
-	"version": "1.0.6-alpha.2",
+	"version": "1.0.6-alpha.3",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/melinda-record-matching",
-			"version": "1.0.6-alpha.2",
+			"version": "1.0.6-alpha.3",
 			"license": "LGPL-3.0+",
 			"dependencies": {
 				"@natlibfi/marc-record": "^6.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@natlibfi/melinda-record-matching",
-	"version": "1.0.6-alpha.1",
+	"version": "1.0.6-alpha.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/melinda-record-matching",
-			"version": "1.0.6-alpha.1",
+			"version": "1.0.6-alpha.2",
 			"license": "LGPL-3.0+",
 			"dependencies": {
 				"@natlibfi/marc-record": "^6.1.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:natlibfi/melinda-record-matching-js.git"
 	},
 	"license": "LGPL-3.0+",
-	"version": "1.0.6-alpha.1",
+	"version": "1.0.6-alpha.2",
 	"main": "./dist/index.js",
 	"engines": {
 		"node": ">=12"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:natlibfi/melinda-record-matching-js.git"
 	},
 	"license": "LGPL-3.0+",
-	"version": "1.0.6-alpha.2",
+	"version": "1.0.6-alpha.3",
 	"main": "./dist/index.js",
 	"engines": {
 		"node": ">=12"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "git@github.com:natlibfi/melinda-record-matching-js.git"
 	},
 	"license": "LGPL-3.0+",
-	"version": "1.0.4",
+	"version": "1.0.6-alpha.1",
 	"main": "./dist/index.js",
 	"engines": {
 		"node": ">=12"

--- a/src/candidate-search/query-list/bib.js
+++ b/src/candidate-search/query-list/bib.js
@@ -87,17 +87,19 @@ export function bibTitle(record) {
 export function bibStandardIdentifiers(record) {
 
   const debug = createDebugLogger('@natlibfi/melinda-record-matching:candidate-search:query:bibStandardIdentifiers');
+  const debugData = debug.extend('data');
   debug(`Creating queries for standard identifiers`);
 
   const fields = record.get(/^(?<def>020|022|024)$/u);
   const identifiers = [].concat(...fields.map(toIdentifiers));
   const uniqueIdentifiers = [...new Set(identifiers)];
 
-  debug(`Identifiers (${identifiers.length}): ${JSON.stringify(identifiers)}`);
-  debug(`Standard identifier fields: ${JSON.stringify(fields)}`);
-  debug(`Unique identifiers (${uniqueIdentifiers.length}): ${JSON.stringify(uniqueIdentifiers)}`);
+  debugData(`Standard identifier fields: ${JSON.stringify(fields)}`);
+  debugData(`Identifiers (${identifiers.length}): ${JSON.stringify(identifiers)}`);
+  debugData(`Unique identifiers (${uniqueIdentifiers.length}): ${JSON.stringify(uniqueIdentifiers)}`);
 
   if (uniqueIdentifiers.length < 1) {
+    debug(`No identifiers found, no queries created.`);
     return [];
   }
 
@@ -108,8 +110,8 @@ export function bibStandardIdentifiers(record) {
     const pairs = toPairs(identifiers);
     const queries = pairs.map(([a, b]) => b ? `dc.identifier=${a} or dc.identifier=${b}` : `dc.identifier=${a}`);
 
-    debug(`Pairs (${pairs.length}): ${JSON.stringify(pairs)}`);
-    debug(`Queries (${queries.length}): ${JSON.stringify(queries)}`);
+    debugData(`Pairs (${pairs.length}): ${JSON.stringify(pairs)}`);
+    debugData(`Queries (${queries.length}): ${JSON.stringify(queries)}`);
 
     return queries;
 

--- a/src/candidate-search/query-list/bib.js
+++ b/src/candidate-search/query-list/bib.js
@@ -123,6 +123,7 @@ export function bibStandardIdentifiers(record) {
 
   function toIdentifiers({tag, subfields}) {
     const issnIsbnReqExp = (/^[A-Za-z0-9-]+$/u);
+    const otherIdReqExp = (/^[A-Za-z0-9-:]+$/u);
 
     if (tag === '022') {
       return subfields
@@ -137,7 +138,7 @@ export function bibStandardIdentifiers(record) {
     }
 
     return subfields
-      .filter(sub => ['a', 'z'].includes(sub.code) && sub.value !== undefined)
+      .filter(sub => ['a', 'z'].includes(sub.code) && otherIdReqExp.test(sub.value) && sub.value !== undefined)
       .map(({value}) => value);
   }
 }

--- a/test-fixtures/candidate-search/query-list/bib/standardIdentifiers/05/metadata.json
+++ b/test-fixtures/candidate-search/query-list/bib/standardIdentifiers/05/metadata.json
@@ -1,6 +1,5 @@
 {
   "description": "Should generate standard identifier query (several fields with several subfields)",
-  "enabled": true,
   "type": "bibStandardIdentifiers",
   "expectedQuery": [
     "dc.identifier=951-772-249-4 or dc.identifier=951-772-249-X",

--- a/test-fixtures/candidate-search/query-list/bib/standardIdentifiers/06/metadata.json
+++ b/test-fixtures/candidate-search/query-list/bib/standardIdentifiers/06/metadata.json
@@ -1,6 +1,5 @@
 {
   "description": "Should not generate 'undefined' standard identifier query (ISSN with colon)",
-  "enabled": true,
   "type": "bibStandardIdentifiers",
   "expectedQuery": [],
   "inputRecord": {

--- a/test-fixtures/candidate-search/query-list/bib/standardIdentifiers/07/metadata.json
+++ b/test-fixtures/candidate-search/query-list/bib/standardIdentifiers/07/metadata.json
@@ -1,6 +1,6 @@
 {
-  "description": "DISABLED: Should not generate standard identifier query from identifier value including not allowed characters (ISSN)",
-  "enabled": false,
+  "description": "Should not generate standard identifier query from identifier value including not allowed characters (ISSN)",
+  "enabled": true,
   "type": "bibStandardIdentifiers",
   "expectedQuery": [],
   "inputRecord": {

--- a/test-fixtures/candidate-search/query-list/bib/standardIdentifiers/07/metadata.json
+++ b/test-fixtures/candidate-search/query-list/bib/standardIdentifiers/07/metadata.json
@@ -1,6 +1,5 @@
 {
   "description": "Should not generate standard identifier query from identifier value including not allowed characters (ISSN)",
-  "enabled": true,
   "type": "bibStandardIdentifiers",
   "expectedQuery": [],
   "inputRecord": {

--- a/test-fixtures/candidate-search/query-list/bib/standardIdentifiers/08/metadata.json
+++ b/test-fixtures/candidate-search/query-list/bib/standardIdentifiers/08/metadata.json
@@ -1,5 +1,5 @@
 {
-  "description": "Should not generate 'undefined' standard identifier query (ISSN with colon)",
+  "description": "Should not generate queries from fields with no valid subfields",
   "enabled": true,
   "type": "bibStandardIdentifiers",
   "expectedQuery": [],
@@ -16,8 +16,8 @@
         "ind2": " ",
         "subfields": [
           {
-            "code": "a",
-            "value": "2049:3630"
+            "code": "e",
+            "value": "2049-3630"
           }
         ]
       }

--- a/test-fixtures/candidate-search/query-list/bib/standardIdentifiers/08/metadata.json
+++ b/test-fixtures/candidate-search/query-list/bib/standardIdentifiers/08/metadata.json
@@ -1,6 +1,5 @@
 {
   "description": "Should not generate queries from fields with no valid subfields",
-  "enabled": true,
   "type": "bibStandardIdentifiers",
   "expectedQuery": [],
   "inputRecord": {

--- a/test-fixtures/candidate-search/query-list/bib/standardIdentifiers/09/metadata.json
+++ b/test-fixtures/candidate-search/query-list/bib/standardIdentifiers/09/metadata.json
@@ -1,6 +1,5 @@
 {
   "description": "Should not generate standard identifier query from identifier value that includes just whitespace (ISSN)",
-  "enabled": true,
   "type": "bibStandardIdentifiers",
   "expectedQuery": [],
   "inputRecord": {

--- a/test-fixtures/candidate-search/query-list/bib/standardIdentifiers/09/metadata.json
+++ b/test-fixtures/candidate-search/query-list/bib/standardIdentifiers/09/metadata.json
@@ -1,5 +1,5 @@
 {
-  "description": "Should not generate 'undefined' standard identifier query (ISSN with colon)",
+  "description": "Should not generate standard identifier query from identifier value that includes just whitespace (ISSN)",
   "enabled": true,
   "type": "bibStandardIdentifiers",
   "expectedQuery": [],
@@ -17,7 +17,7 @@
         "subfields": [
           {
             "code": "a",
-            "value": "2049:3630"
+            "value": " "
           }
         ]
       }

--- a/test-fixtures/candidate-search/query-list/bib/standardIdentifiers/10/metadata.json
+++ b/test-fixtures/candidate-search/query-list/bib/standardIdentifiers/10/metadata.json
@@ -1,5 +1,5 @@
 {
-  "description": "Should not generate 'undefined' standard identifier query (ISSN with colon)",
+  "description": "Should not generate standard identifier query if there are no valid fields",
   "enabled": true,
   "type": "bibStandardIdentifiers",
   "expectedQuery": [],
@@ -11,13 +11,13 @@
         "value": "000019643"
       },
       {
-        "tag": "022",
+        "tag": "822",
         "ind1": " ",
         "ind2": " ",
         "subfields": [
           {
             "code": "a",
-            "value": "2049:3630"
+            "value": "foobar"
           }
         ]
       }

--- a/test-fixtures/candidate-search/query-list/bib/standardIdentifiers/10/metadata.json
+++ b/test-fixtures/candidate-search/query-list/bib/standardIdentifiers/10/metadata.json
@@ -1,6 +1,5 @@
 {
   "description": "Should not generate standard identifier query if there are no valid fields",
-  "enabled": true,
   "type": "bibStandardIdentifiers",
   "expectedQuery": [],
   "inputRecord": {

--- a/test-fixtures/candidate-search/query-list/bib/standardIdentifiers/11/metadata.json
+++ b/test-fixtures/candidate-search/query-list/bib/standardIdentifiers/11/metadata.json
@@ -4,8 +4,7 @@
   "type": "bibStandardIdentifiers",
   "expectedQuery": [
     "dc.identifier=951-772-249-4 or dc.identifier=951-772-249-X",
-    "dc.identifier=9999-772-249-4 or dc.identifier=951-772-249-5",
-    "dc.identifier=959-772-249-X"
+    "dc.identifier=9999-772-249-4"
   ],
   "inputRecord": {
     "leader": "02518cam a2200745zi 4500",
@@ -30,21 +29,6 @@
           {
             "code": "z",
             "value": "9999-772-249-4"
-          }
-        ]
-      },
-      {
-        "tag": "020",
-        "ind1": " ",
-        "ind2": " ",
-        "subfields": [
-          {
-            "code": "a",
-            "value": "951-772-249-5"
-          },
-          {
-            "code": "z",
-            "value": "959-772-249-X"
           }
         ]
       }

--- a/test-fixtures/candidate-search/query-list/bib/standardIdentifiers/11/metadata.json
+++ b/test-fixtures/candidate-search/query-list/bib/standardIdentifiers/11/metadata.json
@@ -1,6 +1,5 @@
 {
   "description": "Should generate standard identifier query (several fields with several subfields)",
-  "enabled": true,
   "type": "bibStandardIdentifiers",
   "expectedQuery": [
     "dc.identifier=951-772-249-4 or dc.identifier=951-772-249-X",

--- a/test-fixtures/candidate-search/query-list/bib/standardIdentifiers/12/metadata.json
+++ b/test-fixtures/candidate-search/query-list/bib/standardIdentifiers/12/metadata.json
@@ -1,11 +1,9 @@
 {
-  "description": "Should generate standard identifier query (several fields with several subfields)",
+  "description": "Should generate queries only for unique identifiers",
   "enabled": true,
   "type": "bibStandardIdentifiers",
   "expectedQuery": [
-    "dc.identifier=951-772-249-4 or dc.identifier=951-772-249-X",
-    "dc.identifier=9999-772-249-4 or dc.identifier=951-772-249-5",
-    "dc.identifier=959-772-249-X"
+    "dc.identifier=951-772-249-4 or dc.identifier=951-772-249-X"
   ],
   "inputRecord": {
     "leader": "02518cam a2200745zi 4500",
@@ -26,10 +24,6 @@
           {
             "code": "z",
             "value": "951-772-249-X"
-          },
-          {
-            "code": "z",
-            "value": "9999-772-249-4"
           }
         ]
       },
@@ -40,11 +34,7 @@
         "subfields": [
           {
             "code": "a",
-            "value": "951-772-249-5"
-          },
-          {
-            "code": "z",
-            "value": "959-772-249-X"
+            "value": "951-772-249-4"
           }
         ]
       }

--- a/test-fixtures/candidate-search/query-list/bib/standardIdentifiers/12/metadata.json
+++ b/test-fixtures/candidate-search/query-list/bib/standardIdentifiers/12/metadata.json
@@ -1,6 +1,5 @@
 {
   "description": "Should generate queries only for unique identifiers",
-  "enabled": true,
   "type": "bibStandardIdentifiers",
   "expectedQuery": [
     "dc.identifier=951-772-249-4 or dc.identifier=951-772-249-X"

--- a/test-fixtures/candidate-search/query-list/bib/standardIdentifiers/13/metadata.json
+++ b/test-fixtures/candidate-search/query-list/bib/standardIdentifiers/13/metadata.json
@@ -1,0 +1,47 @@
+{
+  "description": "DISABLED: Should not generate queries for non valid identifiers (only punctuation+whitespace)",
+  "enabled": true,
+  "type": "bibStandardIdentifiers",
+  "expectedQuery": [
+    "dc.identifier=951-772-249-4"
+  ],
+  "inputRecord": {
+    "leader": "02518cam a2200745zi 4500",
+    "fields": [
+      {
+        "tag": "001",
+        "value": "000019643"
+      },
+      {
+        "tag": "020",
+        "ind1": " ",
+        "ind2": " ",
+        "subfields": [
+          {
+            "code": "a",
+            "value": "951-772-249-4"
+          },
+          {
+            "code": "z",
+            "value": " :,,-\".."
+          }
+        ]
+      },
+      {
+        "tag": "024",
+        "ind1": " ",
+        "ind2": " ",
+        "subfields": [
+          {
+            "code": "a",
+            "value": " ---..\"_;;;"
+          },
+          {
+            "code": "a",
+            "value": ";; URN:1234"
+          }          
+        ]
+      }
+    ]
+  }
+}

--- a/test-fixtures/candidate-search/query-list/bib/standardIdentifiers/13/metadata.json
+++ b/test-fixtures/candidate-search/query-list/bib/standardIdentifiers/13/metadata.json
@@ -1,6 +1,5 @@
 {
   "description": "Should not generate queries for non valid identifiers (only punctuation+whitespace)",
-  "enabled": true,
   "type": "bibStandardIdentifiers",
   "expectedQuery": [
     "dc.identifier=951-772-249-4"

--- a/test-fixtures/candidate-search/query-list/bib/standardIdentifiers/13/metadata.json
+++ b/test-fixtures/candidate-search/query-list/bib/standardIdentifiers/13/metadata.json
@@ -1,5 +1,5 @@
 {
-  "description": "DISABLED: Should not generate queries for non valid identifiers (only punctuation+whitespace)",
+  "description": "Should not generate queries for non valid identifiers (only punctuation+whitespace)",
   "enabled": true,
   "type": "bibStandardIdentifiers",
   "expectedQuery": [


### PR DESCRIPTION
1) Fix generating candidate search queries for standard identifiers:

- generate search query for identifiers for all valid subfields of a standard identifier field instead of just two first subfields [MELKEHITYS-1850]
- do not generate search queries with 'undefined' as identifier [MELKEHITYS-1852]
- do not generate duplicate search queries (even if same identifier string is found multiple times in record) [MELKEHITYS-1854]
- generate search query only for valid identifier strings for other fields (non 020/022) [MELKEHITYS-1848]

2) Add debugData to use '**:data**' namespace for very verbose debug output [MELKEHITYS-1843]