### PR TITLE
Saamelaisbibliografia

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,11 @@
 			"dependencies": {
 				"@natlibfi/marc-record": "^10.0.1",
 				"@natlibfi/marc-record-serializers": "^11.0.1",
+				"@natlibfi/marc-record-validators-melinda": "^12.0.4",
 				"@natlibfi/melinda-commons": "^14.0.2",
 				"@natlibfi/sru-client": "^7.0.1",
 				"debug": "^4.4.3",
-				"isbn3": "^2.0.2",
+				"isbn3": "^2.0.3",
 				"moment": "^2.30.1",
 				"natural": "^8.1.0",
 				"uuid": "^13.0.0",
@@ -25,7 +26,7 @@
 			},
 			"devDependencies": {
 				"@natlibfi/fixugen": "^3.0.0",
-				"@natlibfi/fixugen-http-client": "^4.0.1",
+				"@natlibfi/fixugen-http-client": "^4.0.2",
 				"@natlibfi/fixura": "^4.0.0",
 				"cross-env": "^10.1.0",
 				"esbuild": "^0.27.2",
@@ -33,6 +34,18 @@
 			},
 			"engines": {
 				"node": ">=22"
+			}
+		},
+		"node_modules/@babel/runtime-corejs3": {
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.28.6.tgz",
+			"integrity": "sha512-kz2fAQ5UzjV7X7D3ySxmj3vRq89dTpqOZWv76Z6pNPztkwb/0Yj1Mtx1xFrYj6mbIHysxtBot8J4o0JLCblcFw==",
+			"license": "MIT",
+			"dependencies": {
+				"core-js-pure": "^3.43.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@colors/colors": {
@@ -741,9 +754,9 @@
 			}
 		},
 		"node_modules/@natlibfi/fixugen-http-client": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/@natlibfi/fixugen-http-client/-/fixugen-http-client-4.0.1.tgz",
-			"integrity": "sha512-WpVohO8eFtWZSLC8YNDBkyrk0w4OIPlNUjOHICgFHUaZtwNaqNgJLkS0g4/zz0RW4bZAayNptfv/k2idUWnjNw==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@natlibfi/fixugen-http-client/-/fixugen-http-client-4.0.2.tgz",
+			"integrity": "sha512-5sJaV6YdZHeZg5AVPFu5xKoFAZPzkb9tWsTjXfhHmd8cC/UYE1H65Y3H7BcO0+Aq1rOHKBDFG//CziCIf7qGsQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -761,6 +774,27 @@
 			"resolved": "https://registry.npmjs.org/@natlibfi/fixura/-/fixura-4.0.0.tgz",
 			"integrity": "sha512-ONxPpEQtfu9K9K8KIjcB+ggRW4Tcc4YFe34Dzm+NeAbAFEP/QFlChoV8wlVFfE20o9kLIJijNN3wT90y7GTGQg==",
 			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=22"
+			}
+		},
+		"node_modules/@natlibfi/iso9-1995": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@natlibfi/iso9-1995/-/iso9-1995-1.1.0.tgz",
+			"integrity": "sha512-pDQKeV9ZWJj0i1u0x60VG2mGvmFtUrbTnA9vhyfMHr7FVakCDkI9fzr3u7db4I4pP9hJlH8+zHmjAxgAz3Ppig==",
+			"license": "MIT",
+			"dependencies": {
+				"debug": "^4.4.3"
+			},
+			"engines": {
+				"node": ">=22"
+			}
+		},
+		"node_modules/@natlibfi/issn-verify": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@natlibfi/issn-verify/-/issn-verify-2.0.1.tgz",
+			"integrity": "sha512-suFZLEGq0sg/cbMQ7i5D0W3zUHAv+uQCFT8b3Ik9ddMUe/cBu8a6oBa5gjaNUJGrTeozh5Y4x1h8j2kiU+RDsQ==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=22"
@@ -798,6 +832,48 @@
 				"node": ">=22"
 			}
 		},
+		"node_modules/@natlibfi/marc-record-validate": {
+			"version": "9.0.0",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-validate/-/marc-record-validate-9.0.0.tgz",
+			"integrity": "sha512-6tgcpVt8Cze7xijV0XVrSPd36vMe0xR+fNVjNaFI86HHqK+6wIcIbCtSRILKB5+1RN91J/Mmgp42A7qgQnZCIQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@natlibfi/marc-record": "^10.0.0"
+			},
+			"engines": {
+				"node": ">=22"
+			}
+		},
+		"node_modules/@natlibfi/marc-record-validators-melinda": {
+			"version": "12.0.4",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-validators-melinda/-/marc-record-validators-melinda-12.0.4.tgz",
+			"integrity": "sha512-PmssCOXhtnm3B21wIEBNmS8NJ9LPW6bVwQK0g7Sz4DVbTrdkFWYcSucvlYLcLvZGiKhqsbqFr3zjmjAnBPh+Aw==",
+			"license": "MIT",
+			"dependencies": {
+				"@natlibfi/iso9-1995": "^1.0.0",
+				"@natlibfi/issn-verify": "^2.0.0",
+				"@natlibfi/marc-record": "^10.0.1",
+				"@natlibfi/marc-record-serializers": "^11.0.1",
+				"@natlibfi/marc-record-validate": "^9.0.0",
+				"@natlibfi/melinda-commons": "^14.0.2",
+				"@natlibfi/sfs-4900": "^2.0.0",
+				"@natlibfi/sru-client": "^7.0.1",
+				"cld3-asm": "^4.0.0",
+				"clone": "^2.1.2",
+				"debug": "^4.4.3",
+				"isbn3": "^2.0.2",
+				"langs": "^2.0.0",
+				"undici": "^7.18.0",
+				"xml2js": "^0.6.2",
+				"xregexp": "^5.1.2"
+			},
+			"engines": {
+				"node": ">=22"
+			},
+			"peerDependencies": {
+				"@natlibfi/marc-record-validate": "^9.0.0"
+			}
+		},
 		"node_modules/@natlibfi/melinda-backend-commons": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/@natlibfi/melinda-backend-commons/-/melinda-backend-commons-3.0.2.tgz",
@@ -833,6 +909,15 @@
 				"@natlibfi/sru-client": "^7.0.1",
 				"debug": "^4.4.3"
 			},
+			"engines": {
+				"node": ">=22"
+			}
+		},
+		"node_modules/@natlibfi/sfs-4900": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@natlibfi/sfs-4900/-/sfs-4900-2.0.0.tgz",
+			"integrity": "sha512-DHVT4orHD2hJ0/NAUbqcnixdjGjT6wCLMCZO6o1WcLFLdXok+/v3OnOfnQJKN5uZLYTQKK3pt/y7D3BDKX3chw==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=22"
 			}
@@ -1221,6 +1306,18 @@
 				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
+		"node_modules/cld3-asm": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/cld3-asm/-/cld3-asm-4.0.0.tgz",
+			"integrity": "sha512-eQq2detA7A54X9NSeunvHf4KcWlZKE/i98+V6NjWNDqF28GGk8Qk9XWApSywBjEcmPKR48zkabFWBoa1ExM/AQ==",
+			"license": "MIT",
+			"dependencies": {
+				"emscripten-wasm-loader": "^3.0.3"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
 		"node_modules/cliui": {
 			"version": "9.0.1",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
@@ -1233,6 +1330,15 @@
 			},
 			"engines": {
 				"node": ">=20"
+			}
+		},
+		"node_modules/clone": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+			"integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.8"
 			}
 		},
 		"node_modules/cluster-key-slot": {
@@ -1323,6 +1429,17 @@
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/core-js-pure": {
+			"version": "3.47.0",
+			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.47.0.tgz",
+			"integrity": "sha512-BcxeDbzUrRnXGYIVAGFtcGQVNpFcUhVjr6W7F8XktvQW2iJP9e66GP6xdKotCRFlrxBvNIBrhwKteRXqMV86Nw==",
+			"hasInstallScript": true,
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/core-js"
+			}
 		},
 		"node_modules/corser": {
 			"version": "2.0.1",
@@ -1485,6 +1602,20 @@
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
 			"integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
 			"license": "MIT"
+		},
+		"node_modules/emscripten-wasm-loader": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/emscripten-wasm-loader/-/emscripten-wasm-loader-3.0.3.tgz",
+			"integrity": "sha512-fyq2maBt5LOou27LEBlL5H6G04BxgSamXkvmMsAuIT6rd8ioH4BxNQhuyl6jVPeODh6U8Wk1BoFZxzHpg3o8wA==",
+			"license": "MIT",
+			"dependencies": {
+				"getroot": "^1.0.0",
+				"nanoid": "^2.0.3",
+				"unixify": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
 		},
 		"node_modules/enabled": {
 			"version": "2.0.0",
@@ -2025,6 +2156,19 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/getroot": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/getroot/-/getroot-1.0.0.tgz",
+			"integrity": "sha512-W9Q31kOv921dQuZBeAbK4R/dAPbC0WkhZD3alLcdVwjSkEtS1aX8twrzG3I5yo0sQ88M/d4JOqVbRiCuI/XPNA==",
+			"license": "MIT",
+			"dependencies": {
+				"tslib": "^1.7.1"
+			},
+			"engines": {
+				"node": ">=4.2.4",
+				"npm": ">=3.0.0"
+			}
+		},
 		"node_modules/glob-parent": {
 			"version": "6.0.2",
 			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -2300,9 +2444,9 @@
 			}
 		},
 		"node_modules/isbn3": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/isbn3/-/isbn3-2.0.2.tgz",
-			"integrity": "sha512-cZ5Khq29M9gbzVRQ9fpNFiKZixRUDCU02wVYdEWs2xTMBqGqVG9kXNr0QDc3vugXJDPrBOV2WfmIoeNGLQOWhg==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/isbn3/-/isbn3-2.0.3.tgz",
+			"integrity": "sha512-HDDcGtTyvZK5TBV6PYntlSH3SFEgC0idO1HJT69xNCx/ZmW5oxwHvHtY+Cd1e++18sPcS/Fs4q1EfXeFM/EmLg==",
 			"license": "MIT",
 			"bin": {
 				"isbn": "bin/isbn",
@@ -2393,6 +2537,12 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
 			"integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
+			"license": "MIT"
+		},
+		"node_modules/langs": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/langs/-/langs-2.0.0.tgz",
+			"integrity": "sha512-v4pxOBEQVN1WBTfB1crhTtxzNLZU9HPWgadlwzWKISJtt6Ku/CnpBrwVy+jFv8StjxsPfwPFzO0CMwdZLJ0/BA==",
 			"license": "MIT"
 		},
 		"node_modules/leac": {
@@ -2636,6 +2786,24 @@
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
 			"license": "MIT"
 		},
+		"node_modules/nanoid": {
+			"version": "3.3.11",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+			"integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/ai"
+				}
+			],
+			"license": "MIT",
+			"bin": {
+				"nanoid": "bin/nanoid.cjs"
+			},
+			"engines": {
+				"node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+			}
+		},
 		"node_modules/natural": {
 			"version": "8.1.0",
 			"resolved": "https://registry.npmjs.org/natural/-/natural-8.1.0.tgz",
@@ -2704,6 +2872,18 @@
 			"license": "MIT-0",
 			"engines": {
 				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/normalize-path": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+			"integrity": "sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==",
+			"license": "MIT",
+			"dependencies": {
+				"remove-trailing-separator": "^1.0.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/object-inspect": {
@@ -2849,14 +3029,14 @@
 			}
 		},
 		"node_modules/pg": {
-			"version": "8.16.3",
-			"resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
-			"integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
+			"version": "8.17.1",
+			"resolved": "https://registry.npmjs.org/pg/-/pg-8.17.1.tgz",
+			"integrity": "sha512-EIR+jXdYNSMOrpRp7g6WgQr7SaZNZfS7IzZIO0oTNEeibq956JxeD15t3Jk3zZH0KH8DmOIx38qJfQenoE8bXQ==",
 			"license": "MIT",
 			"dependencies": {
-				"pg-connection-string": "^2.9.1",
-				"pg-pool": "^3.10.1",
-				"pg-protocol": "^1.10.3",
+				"pg-connection-string": "^2.10.0",
+				"pg-pool": "^3.11.0",
+				"pg-protocol": "^1.11.0",
 				"pg-types": "2.2.0",
 				"pgpass": "1.0.5"
 			},
@@ -2864,7 +3044,7 @@
 				"node": ">= 16.0.0"
 			},
 			"optionalDependencies": {
-				"pg-cloudflare": "^1.2.7"
+				"pg-cloudflare": "^1.3.0"
 			},
 			"peerDependencies": {
 				"pg-native": ">=3.0.1"
@@ -2876,16 +3056,16 @@
 			}
 		},
 		"node_modules/pg-cloudflare": {
-			"version": "1.2.7",
-			"resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.2.7.tgz",
-			"integrity": "sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+			"integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
 			"license": "MIT",
 			"optional": true
 		},
 		"node_modules/pg-connection-string": {
-			"version": "2.9.1",
-			"resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.9.1.tgz",
-			"integrity": "sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==",
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.10.0.tgz",
+			"integrity": "sha512-ur/eoPKzDx2IjPaYyXS6Y8NSblxM7X64deV2ObV57vhjsWiwLvUD6meukAzogiOsu60GO8m/3Cb6FdJsWNjwXg==",
 			"license": "MIT"
 		},
 		"node_modules/pg-int8": {
@@ -2898,18 +3078,18 @@
 			}
 		},
 		"node_modules/pg-pool": {
-			"version": "3.10.1",
-			"resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.10.1.tgz",
-			"integrity": "sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==",
+			"version": "3.11.0",
+			"resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.11.0.tgz",
+			"integrity": "sha512-MJYfvHwtGp870aeusDh+hg9apvOe2zmpZJpyt+BMtzUWlVqbhFmMK6bOBXLBUPd7iRtIF9fZplDc7KrPN3PN7w==",
 			"license": "MIT",
 			"peerDependencies": {
 				"pg": ">=8.0"
 			}
 		},
 		"node_modules/pg-protocol": {
-			"version": "1.10.3",
-			"resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
-			"integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.11.0.tgz",
+			"integrity": "sha512-pfsxk2M9M3BuGgDOfuy37VNRRX3jmKgMjcvAcWqNDpZSf4cUmv8HSOl5ViRQFsfARFn0KuUQTgLxVMbNq5NW3g==",
 			"license": "MIT"
 		},
 		"node_modules/pg-types": {
@@ -3064,6 +3244,12 @@
 				"@redis/time-series": "1.1.0"
 			}
 		},
+		"node_modules/remove-trailing-separator": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+			"integrity": "sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==",
+			"license": "ISC"
+		},
 		"node_modules/requires-port": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -3102,10 +3288,13 @@
 			"license": "MIT"
 		},
 		"node_modules/sax": {
-			"version": "1.4.3",
-			"resolved": "https://registry.npmjs.org/sax/-/sax-1.4.3.tgz",
-			"integrity": "sha512-yqYn1JhPczigF94DMS+shiDMjDowYO6y9+wB/4WgO0Y19jWYk0lQ4tuG5KI7kj4FTp1wxPj5IFfcrz/s1c3jjQ==",
-			"license": "BlueOak-1.0.0"
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.4.4.tgz",
+			"integrity": "sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==",
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": ">=11.0.0"
+			}
 		},
 		"node_modules/secure-compare": {
 			"version": "3.0.1",
@@ -3405,6 +3594,12 @@
 				"node": ">= 14.0.0"
 			}
 		},
+		"node_modules/tslib": {
+			"version": "1.14.1",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+			"license": "0BSD"
+		},
 		"node_modules/type-check": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -3424,6 +3619,15 @@
 			"integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
 			"license": "MIT"
 		},
+		"node_modules/undici": {
+			"version": "7.18.2",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.18.2.tgz",
+			"integrity": "sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=20.18.1"
+			}
+		},
 		"node_modules/union": {
 			"version": "0.5.0",
 			"resolved": "https://registry.npmjs.org/union/-/union-0.5.0.tgz",
@@ -3433,6 +3637,18 @@
 			},
 			"engines": {
 				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/unixify": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unixify/-/unixify-1.0.0.tgz",
+			"integrity": "sha512-6bc58dPYhCMHHuwxldQxO3RRNZ4eCogZ/st++0+fcC1nr0jiGUtAdBJ2qzmLQWSxbtz42pWt4QQMiZ9HvZf5cg==",
+			"license": "MIT",
+			"dependencies": {
+				"normalize-path": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/uri-js": {
@@ -3625,6 +3841,15 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=4.0"
+			}
+		},
+		"node_modules/xregexp": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/xregexp/-/xregexp-5.1.2.tgz",
+			"integrity": "sha512-6hGgEMCGhqCTFEJbqmWrNIPqfpdirdGWkqshu7fFZddmTSfgv5Sn9D2SaKloR79s5VUiUlpwzg3CM3G6D3VIlw==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime-corejs3": "^7.26.9"
 			}
 		},
 		"node_modules/xtend": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -845,13 +845,13 @@
 			}
 		},
 		"node_modules/@natlibfi/marc-record-validators-melinda": {
-			"version": "12.0.4",
-			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-validators-melinda/-/marc-record-validators-melinda-12.0.4.tgz",
-			"integrity": "sha512-PmssCOXhtnm3B21wIEBNmS8NJ9LPW6bVwQK0g7Sz4DVbTrdkFWYcSucvlYLcLvZGiKhqsbqFr3zjmjAnBPh+Aw==",
+			"version": "12.0.5",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-validators-melinda/-/marc-record-validators-melinda-12.0.5.tgz",
+			"integrity": "sha512-4H9kBuiS0lnF8TlzstkM6tmGCw5r4CA3wTOIOoLE6RUATDLpfBHdRWaod3zx/FNoLYXfafy4eGJKUKKZFEQERw==",
 			"license": "MIT",
 			"dependencies": {
-				"@natlibfi/iso9-1995": "^1.0.0",
-				"@natlibfi/issn-verify": "^2.0.0",
+				"@natlibfi/iso9-1995": "^1.1.0",
+				"@natlibfi/issn-verify": "^2.0.1",
 				"@natlibfi/marc-record": "^10.0.1",
 				"@natlibfi/marc-record-serializers": "^11.0.1",
 				"@natlibfi/marc-record-validate": "^9.0.0",
@@ -861,9 +861,8 @@
 				"cld3-asm": "^4.0.0",
 				"clone": "^2.1.2",
 				"debug": "^4.4.3",
-				"isbn3": "^2.0.2",
+				"isbn3": "^2.0.3",
 				"langs": "^2.0.0",
-				"undici": "^7.18.0",
 				"xml2js": "^0.6.2",
 				"xregexp": "^5.1.2"
 			},
@@ -3618,15 +3617,6 @@
 			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
 			"integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
 			"license": "MIT"
-		},
-		"node_modules/undici": {
-			"version": "7.18.2",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.18.2.tgz",
-			"integrity": "sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=20.18.1"
-			}
 		},
 		"node_modules/union": {
 			"version": "0.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
 			"dependencies": {
 				"@natlibfi/marc-record": "^10.0.1",
 				"@natlibfi/marc-record-serializers": "^11.0.1",
-				"@natlibfi/marc-record-validators-melinda": "^12.0.4",
+				"@natlibfi/marc-record-validators-melinda": "^12.0.6",
 				"@natlibfi/melinda-commons": "^14.0.2",
 				"@natlibfi/sru-client": "^7.0.1",
 				"debug": "^4.4.3",
@@ -714,9 +714,9 @@
 			}
 		},
 		"node_modules/@mongodb-js/saslprep": {
-			"version": "1.4.4",
-			"resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.4.tgz",
-			"integrity": "sha512-p7X/ytJDIdwUfFL/CLOhKgdfJe1Fa8uw9seJYvdOmnP9JBWGWHW69HkOixXS6Wy9yvGf1MbhcS6lVmrhy4jm2g==",
+			"version": "1.4.5",
+			"resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.5.tgz",
+			"integrity": "sha512-k64Lbyb7ycCSXHSLzxVdb2xsKGPMvYZfCICXvDsI8Z65CeWQzTEKS4YmGbnqw+U9RBvLPTsB6UCmwkgsDTGWIw==",
 			"license": "MIT",
 			"dependencies": {
 				"sparse-bitfield": "^3.0.3"
@@ -845,9 +845,9 @@
 			}
 		},
 		"node_modules/@natlibfi/marc-record-validators-melinda": {
-			"version": "12.0.5",
-			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-validators-melinda/-/marc-record-validators-melinda-12.0.5.tgz",
-			"integrity": "sha512-4H9kBuiS0lnF8TlzstkM6tmGCw5r4CA3wTOIOoLE6RUATDLpfBHdRWaod3zx/FNoLYXfafy4eGJKUKKZFEQERw==",
+			"version": "12.0.6",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-validators-melinda/-/marc-record-validators-melinda-12.0.6.tgz",
+			"integrity": "sha512-QjXmrZxpw3g2GWafGHJe+ZpoHgvBs2xCAYbikSNI6l6vaZfScj20pcz1G67bMPyp8pa0ST1u6TBsDJpglsDLdg==",
 			"license": "MIT",
 			"dependencies": {
 				"@natlibfi/iso9-1995": "^1.1.0",
@@ -1430,9 +1430,9 @@
 			"license": "MIT"
 		},
 		"node_modules/core-js-pure": {
-			"version": "3.47.0",
-			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.47.0.tgz",
-			"integrity": "sha512-BcxeDbzUrRnXGYIVAGFtcGQVNpFcUhVjr6W7F8XktvQW2iJP9e66GP6xdKotCRFlrxBvNIBrhwKteRXqMV86Nw==",
+			"version": "3.48.0",
+			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.48.0.tgz",
+			"integrity": "sha512-1slJgk89tWC51HQ1AEqG+s2VuwpTRr8ocu4n20QUcH1v9lAN0RXen0Q0AABa/DK1I7RrNWLucplOHMx8hfTGTw==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"funding": {
@@ -2584,9 +2584,9 @@
 			}
 		},
 		"node_modules/lodash": {
-			"version": "4.17.21",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+			"version": "4.17.23",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+			"integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
 			"license": "MIT"
 		},
 		"node_modules/lodash.merge": {
@@ -2737,9 +2737,9 @@
 			}
 		},
 		"node_modules/mongoose": {
-			"version": "8.21.0",
-			"resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.21.0.tgz",
-			"integrity": "sha512-dW2U01gN8EVQT5KAO5AkzjbqWc8A/CsEq15jOzq/M9ISpy8jw3iq7W9ZP135h9zykFOMt3AMxq4+anvt2YNJgw==",
+			"version": "8.22.0",
+			"resolved": "https://registry.npmjs.org/mongoose/-/mongoose-8.22.0.tgz",
+			"integrity": "sha512-LKTPPqD3CVcSZJRzPcwKiSVYTmAvBZeVT0V34vUiqPEo9sBmOEg1y4TpDbUb90Zf2lO4N05ailQnKxiapCN08g==",
 			"license": "MIT",
 			"dependencies": {
 				"bson": "^6.10.4",
@@ -2865,9 +2865,9 @@
 			}
 		},
 		"node_modules/nodemailer": {
-			"version": "7.0.12",
-			"resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.12.tgz",
-			"integrity": "sha512-H+rnK5bX2Pi/6ms3sN4/jRQvYSMltV6vqup/0SFOrxYYY/qoNvhXPlYq3e+Pm9RFJRwrMGbMIwi81M4dxpomhA==",
+			"version": "7.0.13",
+			"resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.13.tgz",
+			"integrity": "sha512-PNDFSJdP+KFgdsG3ZzMXCgquO7I6McjY2vlqILjtJd0hy8wEvtugS9xKRF2NWlPNGxvLCXlTNIae4serI7dinw==",
 			"license": "MIT-0",
 			"engines": {
 				"node": ">=6.0.0"
@@ -3028,12 +3028,12 @@
 			}
 		},
 		"node_modules/pg": {
-			"version": "8.17.1",
-			"resolved": "https://registry.npmjs.org/pg/-/pg-8.17.1.tgz",
-			"integrity": "sha512-EIR+jXdYNSMOrpRp7g6WgQr7SaZNZfS7IzZIO0oTNEeibq956JxeD15t3Jk3zZH0KH8DmOIx38qJfQenoE8bXQ==",
+			"version": "8.17.2",
+			"resolved": "https://registry.npmjs.org/pg/-/pg-8.17.2.tgz",
+			"integrity": "sha512-vjbKdiBJRqzcYw1fNU5KuHyYvdJ1qpcQg1CeBrHFqV1pWgHeVR6j/+kX0E1AAXfyuLUGY1ICrN2ELKA/z2HWzw==",
 			"license": "MIT",
 			"dependencies": {
-				"pg-connection-string": "^2.10.0",
+				"pg-connection-string": "^2.10.1",
 				"pg-pool": "^3.11.0",
 				"pg-protocol": "^1.11.0",
 				"pg-types": "2.2.0",
@@ -3062,9 +3062,9 @@
 			"optional": true
 		},
 		"node_modules/pg-connection-string": {
-			"version": "2.10.0",
-			"resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.10.0.tgz",
-			"integrity": "sha512-ur/eoPKzDx2IjPaYyXS6Y8NSblxM7X64deV2ObV57vhjsWiwLvUD6meukAzogiOsu60GO8m/3Cb6FdJsWNjwXg==",
+			"version": "2.10.1",
+			"resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.10.1.tgz",
+			"integrity": "sha512-iNzslsoeSH2/gmDDKiyMqF64DATUCWj3YJ0wP14kqcsf2TUklwimd+66yYojKwZCA7h2yRNLGug71hCBA2a4sw==",
 			"license": "MIT"
 		},
 		"node_modules/pg-int8": {

--- a/package.json
+++ b/package.json
@@ -39,10 +39,11 @@
 	"dependencies": {
 		"@natlibfi/marc-record": "^10.0.1",
 		"@natlibfi/marc-record-serializers": "^11.0.1",
+		"@natlibfi/marc-record-validators-melinda": "^12.0.4",
 		"@natlibfi/melinda-commons": "^14.0.2",
 		"@natlibfi/sru-client": "^7.0.1",
 		"debug": "^4.4.3",
-		"isbn3": "^2.0.2",
+		"isbn3": "^2.0.3",
 		"moment": "^2.30.1",
 		"natural": "^8.1.0",
 		"uuid": "^13.0.0",
@@ -50,10 +51,14 @@
 	},
 	"devDependencies": {
 		"@natlibfi/fixugen": "^3.0.0",
-		"@natlibfi/fixugen-http-client": "^4.0.1",
+		"@natlibfi/fixugen-http-client": "^4.0.2",
 		"@natlibfi/fixura": "^4.0.0",
 		"cross-env": "^10.1.0",
 		"esbuild": "^0.27.2",
 		"eslint": "^9.39.2"
-	}
+	},
+	"overrides": {
+		"nanoid": "^3.3.8"
+	},
+	"nvolkComment": "cld3-asm 4.0.0 uses emscripten-wasm-loader ^3.0.3 which uses problematic, non-secure nanoid version 2.X.X."
 }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 	"dependencies": {
 		"@natlibfi/marc-record": "^10.0.1",
 		"@natlibfi/marc-record-serializers": "^11.0.1",
-		"@natlibfi/marc-record-validators-melinda": "^12.0.4",
+		"@natlibfi/marc-record-validators-melinda": "^12.0.6",
 		"@natlibfi/melinda-commons": "^14.0.2",
 		"@natlibfi/sru-client": "^7.0.1",
 		"debug": "^4.4.3",

--- a/src/candidate-search/index.js
+++ b/src/candidate-search/index.js
@@ -112,9 +112,14 @@ export default async ({record, searchSpec, url, maxCandidates, maxRecordsPerRequ
   }
 
   function getRecordId(record) {
-    const [field] = record.get(/^001$/u);
-    return field ? field.value : '';
+    const [f001] = record.get(/^001$/u);
+    const [f003] = record.get(/^003$/u);
+    if (f001 && f003) {
+      return `${f003.value}-${f001.value}`;
+    }
+    return f001 ? f001.value : '';
   }
+
 };
 
 export function retrieveRecords(client, query, resultSetOffset) {

--- a/src/candidate-search/query-list/bib.js
+++ b/src/candidate-search/query-list/bib.js
@@ -282,6 +282,10 @@ export function bibTitleAuthorPublisher({record, onlyTitleLength, addYear = fals
         .filter(value => value)
         // In Melinda's index subfield separators are indexed as ' '
         .join(' ');
+
+      if (/^[1-9]$/u.test(field.ind2)) { // Skip non-filing characters
+        return titleString.slice(parseInt(field.ind2));
+      }
       return titleString;
     }
     return false;

--- a/src/candidate-search/query-list/bib.js
+++ b/src/candidate-search/query-list/bib.js
@@ -152,13 +152,8 @@ export function bibHostComponents(record) {
   }
 }
 
-// SRU search dc.title with a search phrase starting with ^ maps currently in Melinda to
-// (probably) to *headings* index TIT
+// SRU search dc.title with a search phrase starting with ^ maps currently in Melinda to (probably) to *headings* index TIT
 // - Aleph cannot currently handle headings searches starting with a boolean - in these cases use word search
-
-// Headings index TIT drops articles etc. from the start of the title according to the filing indicator
-// Currently filing indicator is not implemented - if the title starts with an article and the Melinda
-// record is correctly catalogued using a filing indicator -> dc.title search won't match
 
 export function bibTitle(record) {
   // We get author/publisher only when formatted title is shorter than 5 chars
@@ -220,8 +215,6 @@ export function bibTitleAuthorPublisher({record, onlyTitleLength, addYear = fals
         .trim()
         .replace(/^(.{30}\S*) .*$/, "$1")
         .trim();
-
-      
 
       return formatted;
     }
@@ -329,7 +322,7 @@ export function bibAuthors(record) {
 
     if (field) {
       const authorString = field.subfields
-        .filter(({code}) => ['a'].includes(code))
+        .filter(({code}) => ['a'].includes(code)) // We might use different subfield code sets for X00, X10 and X11?
         .map(({value}) => testStringOrNumber(value) ? String(value) : '')
         .filter(value => value)
         // In Melinda's index subfield separators are indexed as ' '

--- a/src/candidate-search/query-list/bib.js
+++ b/src/candidate-search/query-list/bib.js
@@ -193,13 +193,7 @@ export function bibTitleAuthorPublisher({record, onlyTitleLength, addYear = fals
   debug(`bibTitleAuthorPublisher, onlyTitleLength: ${onlyTitleLength}, addYear: ${addYear}, alternates: ${alternates}`);
   const title = getTitle();
   if (testStringOrNumber(title)) {
-    const formatted = String(title)
-      .replace(/[^\w\s\p{Alphabetic}]/gu, '')
-      // Clean up concurrent spaces from fe. subfield changes
-      .replace(/ +/gu, ' ')
-      .trim()
-      .slice(0, 30)
-      .trim();
+    const formatted = getFormatted(title);
 
     // use word search for titles starting with a boolean
     const useWordSearch = checkUseWordSearch(formatted);
@@ -216,6 +210,21 @@ export function bibTitleAuthorPublisher({record, onlyTitleLength, addYear = fals
     const newAlternateQueries = alternates ? [...alternateQueries, query] : alternateQueries;
 
     return addAuthorsToSearch({query, queryIsOkAlone, addYear, alternates, alternateQueries: newAlternateQueries});
+
+    function getFormatted(title) {
+      const formatted = String(title)
+        .replace(/[\-+ !"(){}\[\]<>;:.?/@*%=^_`~]/gu, ' ')
+        .replace(/[^\w\s\p{Alphabetic}]/gu, '')
+        // Clean up concurrent spaces from fe. subfield changes
+        .replace(/  +/gu, ' ')
+        .trim()
+        .replace(/^(.{30}\S*) .*$/, "$1")
+        .trim();
+
+      
+
+      return formatted;
+    }
   }
 
   return [];
@@ -393,9 +402,10 @@ export function bibYear(record) {
 }
 
 export function checkUseWordSearch(formatted) {
+  const lowercased = formatted.toLowerCase();
   // Note: add a space to startWords to catch just actual boolean words
   const booleanStartWords = ['and ', 'or ', 'nor ', 'not '];
-  return booleanStartWords.some(word => formatted.toLowerCase().startsWith(word));
+  return booleanStartWords.some(word => lowercased.startsWith(word));
 }
 
 export function bibStandardIdentifiers(record) {

--- a/src/cli.js
+++ b/src/cli.js
@@ -55,7 +55,7 @@ async function cli() {
   debug(JSON.stringify(args));
 
   const detection = {
-    treshold: 0.9,
+    threshold: 0.8999,
     strategy: generateStrategy(searchType)
   };
 

--- a/src/index.js
+++ b/src/index.js
@@ -124,7 +124,7 @@ export default ({detection: detectionOptions, search: searchOptions, maxMatches 
     // - candidate.record
     // - probability
     // - strategy (if returnStrategy option is true)
-    // - treshold (if returnStrategy option is true)
+    // - threshold (if returnStrategy option is true)
     // - matchQuery (if returnQuery option is true)
     // failures: array of conversionFailures from candidate-search and matchErrors from matchDetection in error format {status, payload: {message, id}} if returnFailures is true
 
@@ -257,7 +257,7 @@ export default ({detection: detectionOptions, search: searchOptions, maxMatches 
 
         if (detectionResult.match || returnNonMatches) {
           debug(`${detectionResult.match ? `Record ${candidateId} (${newRecordCount}/${recordSetSize}) is a match!` : `Record ${candidateId} (${newRecordCount}/${recordSetSize}) is NOT a match!`}`);
-          debugData(`Strategy: ${JSON.stringify(detectionResult.strategy)}, Treshold: ${JSON.stringify(detectionResult.treshold)}`);
+          debugData(`Strategy: ${JSON.stringify(detectionResult.strategy)}, Threshold: ${JSON.stringify(detectionResult.threshold)}`);
 
           const matchResult = {
             probability: detectionResult.probability,
@@ -268,7 +268,7 @@ export default ({detection: detectionOptions, search: searchOptions, maxMatches 
           };
           const strategyResult = {
             strategy: detectionResult.strategy,
-            treshold: detectionResult.treshold
+            threshold: detectionResult.threshold
           };
           const newMatch = returnStrategy ? {...matchResult, ...strategyResult} : {...matchResult};
 

--- a/src/match-detection/features/bib/authors.js
+++ b/src/match-detection/features/bib/authors.js
@@ -6,7 +6,7 @@ import {testStringOrNumber} from '../../../matching-utils.js';
 
 // We should extract also organisational authors (110/710)
 
-export default ({nameTreshold = 10} = {}) => ({
+export default ({nameThreshold = 10} = {}) => ({
   name: 'Authors',
   extract: ({record}) => {
     //const label = recordExternal && recordExternal.label ? recordExternal.label : 'record';
@@ -58,7 +58,7 @@ export default ({nameTreshold = 10} = {}) => ({
         const maxLength = getMaxLength();
         const percentage = distance / maxLength * 100;
 
-        return percentage <= nameTreshold;
+        return percentage <= nameThreshold;
 
         function getMaxLength() {
           return a.length > b.length ? a.length : b.length;

--- a/src/match-detection/features/bib/bibliographic-level.js
+++ b/src/match-detection/features/bib/bibliographic-level.js
@@ -2,5 +2,17 @@
 export default () => ({
   name: 'Bibliographic level',
   extract: ({record}) => record.leader[7] ? [record.leader[7]] : [],
-  compare: (a, b) => a[0] === b[0] ? 0.1 : -0.2
+  compare: (a, b) => {
+    if (a[0] === b[0]) {
+      return 0.1;
+    }
+    // See MELINDA-7427: We have millions of LDR/07='b' where they should be LDR/07='a'. So don't penalize for these...
+    if (a[0] === 'a' && b[0] === 'b') {
+      return 0.0;
+    }
+    if (a[0] === 'b' && b[0] === 'a') {
+      return 0.0;
+    }
+    return -0.2;
+  }
 });

--- a/src/match-detection/features/bib/host-component.js
+++ b/src/match-detection/features/bib/host-component.js
@@ -1,6 +1,6 @@
 
 export default () => ({
   name: 'Host/Component record',
-  extract: ({record}) => record.get(/^773$/u).length > 0 ? ['component'] : ['host'],
+  extract: ({record}) => record.get(/^[79]73$/u).length > 0 ? ['component'] : ['host'],
   compare: (a, b) => a[0] === b[0] ? 0.0 : -1.0
 });

--- a/src/match-detection/features/bib/isbn.js
+++ b/src/match-detection/features/bib/isbn.js
@@ -2,7 +2,9 @@
 import createDebugLogger from 'debug';
 import {parse as isbnParse} from 'isbn3';
 
-import {isHostRecord, uniqArray} from './issn.js';
+import {uniqArray} from './issn.js';
+import {isComponentRecord} from '@natlibfi/melinda-commons';
+
 
 const debug = createDebugLogger(`@natlibfi/melinda-record-matching:match-detection:features:standard-identifiers:ISBN`);
 const debugData = debug.extend('data');
@@ -14,9 +16,9 @@ export default () => ({
   extract: ({record/*, recordExternal*/}) => {
     //const label = recordExternal && recordExternal.label ? recordExternal.label : 'record';
 
-    const isHost = isHostRecord(record);
+    const host = !isComponentRecord(record, false, []);
 
-    if (isHost) {
+    if (host) {
       return record.get('020').filter(f => f.subfields?.some(sf => ['a', 'z'].includes(sf.code) && sf.value));
     }
     return record.get('773').filter(f => f.subfields?.some(sf => ['z'].includes(sf.code) && sf.value));

--- a/src/match-detection/features/bib/isbn.js
+++ b/src/match-detection/features/bib/isbn.js
@@ -1,26 +1,95 @@
 
 import createDebugLogger from 'debug';
 import {parse as isbnParse} from 'isbn3';
-import createInterface from './standard-identifier-factory.js';
+
+import {isHostRecord} from './issn.js';
 
 const debug = createDebugLogger(`@natlibfi/melinda-record-matching:match-detection:features:standard-identifiers:ISBN`);
 const debugData = debug.extend('data');
 
-export default () => {
-  const IDENTIFIER_NAME = 'ISBN';
+export default () => ({
+  name: 'ISBN',
+  extract: ({record/*, recordExternal*/}) => {
+    //const label = recordExternal && recordExternal.label ? recordExternal.label : 'record';
 
-  function validatorAndNormalizer(string) {
-    const isbnParseResult = isbnParse(string);
-    debugData(`isbnParseResult: ${JSON.stringify(isbnParseResult)}`);
-    if (isbnParseResult === null) {
-      debug(`Not parseable ISBN, just removing hyphens`);
-      return {valid: false, value: string.replace(/-/ug, '')};
+    const isHost = isHostRecord(record);
+
+    if (isHost) {
+      return record.get('020').filter(f => f.subfields?.some(sf => ['a', 'z'].includes(sf.code) && sf.value));
     }
-    debug(`Parseable ISBN, normalizing to ISBN-13`);
-    return {valid: true, value: isbnParseResult.isbn13};
+    return record.get('773').filter(f => f.subfields?.some(sf => ['z'].includes(sf.code) && sf.value));
+  },
+  // eslint-disable-next-line max-statements
+  compare: (aa, bb) => {
+    debugData(`Comparing ISBN sets ${JSON.stringify(aa)} and ${JSON.stringify(bb)}`);
+    if (aa.length === 0 || bb.length === 0) {
+      // No data for decision
+      return 0;
+    }
+
+    const [subfieldCodeForGoodValues, subfieldCodeForBadValues] = getSubfieldCodes(aa[0].tag);
+
+    const [goodValuesA, badValuesA] = getValues(aa);
+    const [goodValuesB, badValuesB] = getValues(bb);
+
+    if (goodValuesA.some(valA => goodValuesB.includes(valA)) || goodValuesB.some(valB => goodValuesA.includes(valB))) {
+      return 0.75;
+    }
+
+    if (goodValuesA.some(valA => badValuesB.includes(valA)) || goodValuesB.some(valB => badValuesA.includes(valB))) {
+      return 0.75;
+    }
+
+    // Value is bad, but looks isbn-ish to a human eye:
+    if (badValuesA.some(valA => looksGood(valA) && badValuesB.includes(valA)) || badValuesB.some(valB => looksGood(valB) && badValuesA.includes(valB))) {
+      return 0.5;
+    }
+
+    if (goodValuesA.length === 0 && goodValuesB === 0) {
+      return 0.0;
+    }
+    return -0.75;
+
+
+    function getSubfieldCodes(tag) {
+      if (tag === '773') {
+        return ['z', undefined];
+      }
+      return ['a', 'z'];
+    }
+
+    function looksGood(val) {
+      // isbn10 can end in X:
+      if (/^([0-9]-?){9}[0-9X]$/u.test(val)) {
+        return true;
+      }
+      // isbn13 can not:
+      if (/^([0-9]-?){12}[0-9]$/u.test(val)) {
+        return true;
+      }
+      return false;
+    }
+
+    function getValues(fields) {
+      const goodValues = fields.flatMap(f => f.subfields.filter(sf => sf.code === subfieldCodeForGoodValues)).map(sf => validatorAndNormalizer(sf.value));
+      const trueGoodValues = goodValues.filter(val => val.valid).map(val => val.value);
+      const wannabeGoodValues = goodValues.filter(val => !val.valid).map(val => val.value);
+      if (!subfieldCodeForBadValues) { // 773
+        return [trueGoodValues, wannabeGoodValues];
+      }
+      const badValues = fields.flatMap(f => f.subfields.filter(sf => sf.code === subfieldCodeForBadValues)).map(sf => sf.value);
+      return [trueGoodValues, [...badValues, ...wannabeGoodValues]];
+    }
+
+    function validatorAndNormalizer(string) {
+      const isbnParseResult = isbnParse(string) || '';
+      debugData(`isbnParseResult: ${JSON.stringify(isbnParseResult)}`);
+      if (isbnParseResult === null) {
+        debug(`Not parseable ISBN, just removing hyphens`);
+        return {valid: false, value: string.replace(/-/ug, '')};
+      }
+      debug(`Parseable ISBN, normalizing to ISBN-13`);
+      return {valid: true, value: isbnParseResult.isbn13};
+    }
   }
-
-  const {extract, compare} = createInterface({identifier: IDENTIFIER_NAME, pattern: /^020$/u, subfieldCodes: ['a', 'z'], validIdentifierSubfieldCodes: ['a'], invalidIdentifierSubfieldCodes: ['z'], validatorAndNormalizer});
-  return {extract, compare, name: IDENTIFIER_NAME};
-};
-
+});

--- a/src/match-detection/features/bib/issn.js
+++ b/src/match-detection/features/bib/issn.js
@@ -23,19 +23,19 @@ export default () => ({
 
     const isHost = !isComponentRecord(record, false, []);
 
-    debug(`\t Is HOST: '${isHost}'`);
+    // debug(`\t Is HOST: '${isHost}'`);
     return getIssns();
 
     function getIssns() {
       const fields = getRelevantFields();
-      debug(`\t N fields: '${fields.length}'`);
       if (fields.length === 0) {
         return [];
       }
+      debug(`\t ${fields.length} potential ISSN fields (${fields[0].tag})`);
       const subfieldCodes = getRelevantSubfieldCodes();
-      debug(`\t subfield codes: '${subfieldCodes.join("', '")}'`);
+      //debug(`\t subfield codes: '${subfieldCodes.join("', '")}'`);
       const subfieldValues = fields.flatMap(f => f.subfields.filter(sf => subfieldCodes.includes(sf.code)).map(sf => sf.value));
-      debug(`\t cand values: '${subfieldValues.join("', '")}'`);
+      //debug(`\t cand values: '${subfieldValues.join("', '")}'`);
       // Stripping punctuaction with substring here is pretty quick and dirty approach...
       const validSubfieldValues = subfieldValues?.map(val => normalizeSubfieldValue(val)).filter(val => isValidIssn(val));
       if (!validSubfieldValues) {

--- a/src/match-detection/features/bib/issn.js
+++ b/src/match-detection/features/bib/issn.js
@@ -10,6 +10,9 @@ export default () => {
 
 
 import createDebugLogger from 'debug';
+
+import {isComponentRecord} from '@natlibfi/melinda-commons';
+
 const debug = createDebugLogger('@natlibfi/melinda-record-matching:match-detection:features:issn');
 const debugData = debug.extend('data');
 
@@ -18,7 +21,8 @@ export default () => ({
   extract: ({record/*, recordExternal*/}) => {
     //const label = recordExternal && recordExternal.label ? recordExternal.label : 'record';
 
-    const isHost = isHostRecord(record);
+    const isHost = !isComponentRecord(record, false, []);
+
     debug(`\t Is HOST: '${isHost}'`);
     return getIssns();
 
@@ -79,11 +83,6 @@ export default () => ({
 
   }
 });
-
-export function isHostRecord(record) {
-  const ldr07 = record.leader?.charAt(7) || '?';
-  return !['a', 'b', 'd'].includes(ldr07);
-}
 
 export function uniqArray(arr) {
   return arr.filter((val, i) => arr.indexOf(val) === i);

--- a/src/match-detection/features/bib/issn.js
+++ b/src/match-detection/features/bib/issn.js
@@ -1,7 +1,90 @@
+/*
+//import createInterface from './standard-identifier-factory.js';
 
-import createInterface from './standard-identifier-factory.js';
 
 export default () => {
   const {extract, compare} = createInterface({pattern: /^022$/u, subfieldCodes: ['a', 'z', 'y']});
   return {extract, compare, name: 'ISSN'};
 };
+*/
+
+
+import createDebugLogger from 'debug';
+const debug = createDebugLogger('@natlibfi/melinda-record-matching:match-detection:features:issn');
+const debugData = debug.extend('data');
+
+export default () => ({
+  name: 'ISSN',
+  extract: ({record/*, recordExternal*/}) => {
+    //const label = recordExternal && recordExternal.label ? recordExternal.label : 'record';
+
+    const isHost = isHostRecord(record);
+    debug(`\t Is HOST: '${isHost}'`);
+    return getIssns();
+
+    function getIssns() {
+      const fields = getRelevantFields();
+      debug(`\t N fields: '${fields.length}'`);
+      if (fields.length === 0) {
+        return [];
+      }
+      const subfieldCodes = getRelevantSubfieldCodes();
+      debug(`\t subfield codes: '${subfieldCodes.join("', '")}'`);
+      const subfieldValues = fields.flatMap(f => f.subfields.filter(sf => subfieldCodes.includes(sf.code)).map(sf => sf.value));
+      debug(`\t cand values: '${subfieldValues.join("', '")}'`);
+      // Stripping punctuaction with substring here is pretty quick and dirty approach...
+      const validSubfieldValues = subfieldValues?.map(val => normalizeSubfieldValue(val)).filter(val => isValidIssn(val));
+      if (!validSubfieldValues) {
+        return [];
+      }
+      return uniqArray(validSubfieldValues);
+    }
+
+    function getRelevantFields() {
+      if (isHost) {
+        return record.get(/^022$/u);
+      }
+      return record.get(/^[79]73$/u);
+    }
+
+    function normalizeSubfieldValue(val) {
+      return val.replace(/[., :;].*$/u, '');
+    }
+
+    function isValidIssn(val) {
+      return /^[0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9X]$/u.test(val);
+    }
+
+    function getRelevantSubfieldCodes() {
+      if (isHost) {
+        return ['a', 'y', 'z'];
+      }
+      return ['x'];
+    }
+  },
+  // eslint-disable-next-line max-statements
+  compare: (aa, bb) => {
+    debugData(`Comparing ISSN sets ${JSON.stringify(aa)} and ${JSON.stringify(bb)}`);
+    if (aa.length === 0 || bb.length === 0) {
+      // No data for decision
+      return 0;
+    }
+    const firstSharedIssn = aa.find(val => bb.includes(val));
+    if (firstSharedIssn) {
+      debug(`\t Shared ISSN found: '${firstSharedIssn}'`);
+      // Maybe less for comps?
+      return 0.2;
+    }
+    return -0.2;
+
+  }
+});
+
+export function isHostRecord(record) {
+  const ldr07 = record.leader?.charAt(7) || '?';
+  return !['a', 'b', 'd'].includes(ldr07);
+}
+
+export function uniqArray(arr) {
+  return arr.filter((val, i) => arr.indexOf(val) === i);
+}

--- a/src/match-detection/features/bib/language.js
+++ b/src/match-detection/features/bib/language.js
@@ -1,111 +1,299 @@
 
 import createDebugLogger from 'debug';
+
+import {MarcRecord} from '@natlibfi/marc-record';
+
+import {FixSami041, Remove041zxx} from '@natlibfi/marc-record-validators-melinda';
+
 import {getMatchCounts} from '../../../matching-utils.js';
 
 const debug = createDebugLogger('@natlibfi/melinda-record-matching:match-detection:features:language');
 const debugData = debug.extend('data');
 
+// NB! 2025-12-17: I changed the logic drastically. However, I tried to keep the scores as same as possible.
+// 'extract' no longer extracts anything. Instead it clones the record, and does some preprocessing (using validators) instead.
+// 'compare' had multiple changes
+// - f041 ind1 differences ('0' vs '1') now result in a small penalty
+// - Two sami languages related changes:
+// -- validator adds a 'smi' subfield before a corresponding sma/sme/...subfield, if needed (national)
+// -- 'smi' only vs 'smi'+'sma' does not cause penalty
+// - 'mul' vs 'fin'+'swe' does not cause a penalty. However, 'mul' vs 'fin' alone triggers penalty.
+// - 008/35-37 and f041$a/$d are calculated separately
+// - a threshold is applied: return value is always between -1.0 and +0.1 (as it was before)
+// - we try to handle 041 $2 ISO 639-2 and ISO 639-3 as well.
+// - 'und' vs one other language does not cause a penalty in certain contexts. In other contexts it's treated as a normal "language code". (Tune/alleviate penalties later on.)
+
 export default () => ({
   name: 'Language',
   extract: ({record, recordExternal}) => {
     const label = recordExternal && recordExternal.label ? recordExternal.label : 'record';
+    const clonedRecord = new MarcRecord(record, record._validationOptions); // clone(record); // NB! This loses record.get()...
 
-    const value008 = get008Value();
-    const values041 = get041Values();
-    debugData(`${label}: 008: ${JSON.stringify(value008)}, 041: ${JSON.stringify(values041)}`);
+    FixSami041().fix(clonedRecord); // Handle 'smi' adding if needed
+    Remove041zxx().fix(clonedRecord); // Remove 'zxx' from f041s
+    // Add other language code normalizations?
 
-    if (!value008 && values041.length < 1) {
-      debugData(`${label}: No actual values found`);
-      return [];
+    // Should we return all the fields, or just the relevant fields?
+    return [{leader: clonedRecord.leader, fields: clonedRecord.fields}, label];
+  },
+  // eslint-disable-next-line max-statements
+  compare: (aa, bb) => {
+    const [a, aLabel] = aa;
+    const [b, bLabel] = bb;
+    debugData(`Comparing language ${JSON.stringify(a)} and ${JSON.stringify(b)}`);
+
+    const score008 = compare008();
+    const score041 = compare041();
+    return applyLimits(score008 + score041);
+
+    function applyLimits(score) {
+      if (score > 0.1) { // Keeps the original max, we might have 0.10 (041) + 0.05 (008/35-37) = 0.15 now
+        return 0.1;
+      }
+      if (score < -1) {
+        return -1.0;
+      }
+      return score;
     }
 
-    const allValues = value008 === undefined ? values041 : values041.concat(value008);
-    const uniqueSortedValues = [...new Set(allValues)].sort();
-
-    return uniqueSortedValues;
-
-    function get008Value() {
-      const value = record.get(/^008$/u)?.[0]?.value || undefined;
-      debugData(`${label}: 008 value: ${value}`);
-
-      if (!value) {
-        return undefined;
+    function compare008() {
+      const a008 = get008Value(a, aLabel);
+      const b008 = get008Value(b, bLabel);
+      // Something seriously wrong with 008:
+      if (a008 === undefined || b008 === undefined) {
+        return 0.0; // Punish for generic badness?
       }
 
-      const code = value.slice(35, 38);
-      debugData(`${label}: 008 code: ${code}`);
-      return isLangCodeForALanguage(code) ? code : undefined;
+      if (containsNoData(a008) || containsNoData(b008)){
+        // Nothing to compare
+        return 0.0;
+      }
+
+      if (a008 === b008) {
+        return 0.05;
+      }
+
+      if (a008 === 'mul' || b008 === 'mul') {
+        return 0.0;
+      }
+
+      return -0.2;
     }
 
-    // Uses only f041s that have 2nd ind ' ', which means that the codes used are MARC 21 language codes
 
-    function get041Values() {
-      return record.get(/^041$/u)
-        .filter(({ind2}) => ind2 === ' ')
+
+
+
+    function compare041() {
+      const a041s = getFields041(a);
+      const b041s = getFields041(b);
+      if (a041s.length === 0 || b041s.length === 0) {
+        return 0.0; // Should we punish these for badness?
+      }
+      if (a041s.length === 1 && b041s.length === 1) {
+        // The language codes are typically same between different sources. Incur a small penalty for differences though...
+        const sourcePenalty = getSourceOfLanguageCode(a041s[0]) === getSourceOfLanguageCode(b041s[0]) ? 0.0 : -0.05;
+        const scoreInd1 = indicator1Penalty(a041s[0], b041s[0]);
+        debug(`\t Indicator penalty: '${scoreInd1}'`);
+        return sourcePenalty + scoreInd1 + compareLanguageCodeLists(getFieldsLanguageCodes(a041s[0]), getFieldsLanguageCodes(b041s[0]));
+      }
+      // Things are already complicated (likely to pe penalized, so no nedd to worrty about language code sources, I daresay.
+      return compareLanguageCodeLists(getLanguageCodesFrom041Fields(a), getLanguageCodesFrom041Fields(b));
+
+      function getFields041(record) {
+        if (!record.fields) {
+          return [];
+        }
+        return record.fields.filter(f => f.tag === '041');
+      }
+
+    }
+
+    function getSourceOfLanguageCode(field) {
+      const sf2 = field.subfields.find(sf => sf.code === '2');
+      if (!sf2) {
+        return 'MARC';
+      }
+      // Normalize the two relevant language code names:
+      if (sf2.value.match(/639.2/u)) {
+        return 'ISO 639-2';
+      }
+      if (sf2.value.match(/639.3/u)) {
+        return 'ISO 639-3';
+      }
+      return sf2.value; // We don't actually have anything else in Melinda though
+    }
+
+    function indicator1Penalty(aField, bField) {
+      if (aField.ind1 === ' ' || bField.ind1 === ' '|| aField.ind1 === bField.ind1 ) {
+        return 0.0;
+      }
+      debug(`\t Indicator penalty: '${aField.ind1}' vs '${bField.ind1}'`);
+      return -0.1;
+    }
+
+
+
+    function containsNoData(languageCode) {
+      return ['   ', '|||', 'und'].includes(languageCode);
+    }
+
+    function compareLanguageCodeLists(a, b) {
+      if (a.length === 0 || b.length === 0) {
+        debugData(`No language to compare`);
+        return 0;
+      }
+
+      // If either one of the sets has only the generic 'smi', remove the specific sami languages codes from the other as well:
+      const samiLanguageCodes = ['sma', 'sme', 'smj', 'smn', 'sms']; // NB! Don't put generic 'smi' here!
+
+      if (a.includes('smi') && b.includes('smi')) {
+        if (a.some(code => samiLanguageCodes.includes(code)) && !b.some(code => samiLanguageCodes.includes(code))) {
+          return compareLanguageCodeLists(a.filter(val => !samiLanguageCodes.includes(val)), b); // recurse
+        }
+        if (b.some(code => samiLanguageCodes.includes(code)) && !a.some(code => samiLanguageCodes.includes(code))) {
+          return compareLanguageCodeLists(a, b.filter(val => !samiLanguageCodes.includes(val))); // recurse
+        }
+      }
+
+
+
+
+      if (a.length === b.length && a.every((element, index) => element === b[index])) {
+        debugData(`All languages match`);
+        return 0.1;
+      }
+
+      // Handle 'mul'. (Should we check whether the other array contains mul as well, probably not...)
+      // (If 'mul' does not appear alone, then it is very iffy... )
+      if (a.length === 1 && a[0] === 'mul' && b.length > 1) {
+        return 0;
+      }
+      if (b.length === 1 && b[0] === 'mul' && a.length > 1) {
+        return 0;
+      }
+
+
+
+      // Damage control:
+
+      // Not using the generic solution here as eg. 'und' needs a special treatment
+      const sharedValues = getSharedValues(a, b);
+      const aOnly = a.filter(val => !sharedValues.includes(val));
+      const bOnly = b.filter(val => !sharedValues.includes(val));
+      const hasUnd = [...aOnly, ...bOnly].includes('und');
+
+      if (sharedValues.length < 1) {
+        console.info(`NV: ${sharedValues.join(", ")}`);
+        if (aOnly.length === 1 && bOnly.length === 1 && hasUnd) {
+          debug(`Both have languages, but none of these match. However, the benefit of doubt is given: '${aOnly[0]}' and '${bOnly[0]}' might mean the same}`);
+          return 0;
+        }
+        debug(`Both have languages, but none of these match.`); // includes 'mul' vs a single language code
+        return -1.0;
+      }
+
+      const {matchingValues, possibleMatchValues, maxValues} = getMatchCounts(a, b);
+
+      debug(`Both have languages, ${matchingValues}/${possibleMatchValues} valid languages match.`);
+      // ignore non-matches if there is mismatching amount of values
+      debug(`Possible matches: ${possibleMatchValues}/${maxValues}`);
+      // we give some kind of penalty for mismatching amount of values instead of simple divide?
+      const missingCount = maxValues - possibleMatchValues;
+      const misMatchCount = possibleMatchValues - matchingValues;
+      debug(`\t missing: ${missingCount}`);
+      debug(`\t mismatches: ${misMatchCount}`);
+
+      const penaltyForMissing = 0.02 * (maxValues - possibleMatchValues);
+      const penaltyForMisMatch = 0.05 * (possibleMatchValues - matchingValues);
+      debug(`\t points: penaltyForMissing: ${penaltyForMissing}`);
+      debug(`\t points: penaltyForMisMatch: ${penaltyForMisMatch}`);
+
+      const points = Number(Number(0.1 - penaltyForMisMatch - penaltyForMissing).toFixed(2));
+      debug(`Total points: ${points}`);
+
+      return points;
+    }
+  }
+
+});
+
+function get008Value(record, label = 'record') {
+  if (!record || !record.fields) {
+    return;
+  }
+  const f008 = record.fields.find(f => f.tag === '008');
+  if (!f008) {
+    return undefined;
+  }
+  const value = f008.value || defaultValue;
+
+  if (!value) {
+    debugData(`${label}: Failed to extact 008/35-37 value from '${value}'`);
+    return defaultValue;
+  }
+
+  const code = value.slice(35, 38);
+  debugData(`${label}: 008 code: '${code}'`);
+  return code;
+}
+
+// Check if a string is a possible, validly formed language code for a single language
+// Currently accept also codes in capitals
+function isLangCodeForALanguage(code, label = 'record', encoding = undefined) {
+  if (!code) {
+    return false;
+  }
+
+  if ([undefined, 'ISO 639-2', 'ISO-639-3'].includes(encoding) && code.length !== 3) {
+    debugData(`${label}: Code ${code} is not correct length (3) for a language code.`);
+    return false;
+  }
+  if (!encoding) {
+    // 'mul' should be passed as 'mul' can match 'fin' + 'swe' etc.
+    // 'zxx' should be removed by a validator
+    // '^^^' is Aleph-specific corruption, not supporting it anymore
+    if (code === '|||' || code === '   ' ) { // || code === '^^^' || code === 'mul' || code === 'zxx') {
+      debugData(`${label}: Code ${code} is not code for a spesific language.`);
+      return false;
+    }
+  }
+  // Marc, ISO 639-2 and ISO 639-3 are all three-letters long. Not other language codes seen in Melinda:
+  const langCodePattern = /^[a-z][a-z][a-z]$/ui;
+  if (!langCodePattern.test(code)) {
+    debugData(`${label}: Code ${code} is not valid as a language code`);
+    return false;
+  }
+  return true;
+}
+
+
+
+function getLanguageCodesFrom041Fields(record) {
+  // NB! We brutally don't check $2 (language code source) as marc's language codes is practically a subset of ISO 639-2,
+  // and also ISO 639-2 and ISO 639-3 overlap to a degree. If we ever run into a trouble with some ISO 639-2 vs 639-3 mismatch, then we'll work it out.
+  // Also we could write a validator that converts ISO 639-2 to marc if applicable and maybe even partial support for ISO-639-3.
+  // Note that ISO 639-2-B values correspond with marc beteer that ISO 639-2-T. Eg. code for Chinese 'zho' should/code be normalized to 'chi'!
+  const values = record.fields.filter(f => f.tag === '041').flatMap(f => getFieldsLanguageCodes(f));
+  /*
+        // .filter(({ind2}) => ind2 === ' ')
         .map(({subfields}) => subfields)
         .flat()
         .filter(({code}) => code === 'a' || code === 'd')
         .filter(({value}) => value && isLangCodeForALanguage(value))
         .map(({value}) => value);
-    }
+    */
+  return [...new Set(values)].sort();
+}
 
-    // Check if a string is a possible, validly formed language code for a single language
-    // Currently accept also codes in capitals
-    function isLangCodeForALanguage(code) {
-      if (code.length !== 3) {
-        debugData(`Code ${code} is not correct length (3) for a language code.`);
-        return false;
-      }
-      if (code === '|||' || code === '   ' || code === '^^^' || code === 'mul' || code === 'zxx') {
-        debugData(`Code ${code} is not code for a spesific language.`);
-        return false;
-      }
-      const langCodePattern = /^[a-z][a-z][a-z]$/ui;
-      if (!langCodePattern.test(code)) {
-        debugData(`Code ${code} is not valid as a language code`);
-        return false;
-      }
-      return true;
-    }
+function getFieldsLanguageCodes(field) {
+  const relevantSubfields = field.subfields.filter(sf => sf.code === 'a' || sf.code === 'd').filter(sf => isLangCodeForALanguage(sf.value, 'field'));
 
-  },
-  // eslint-disable-next-line max-statements
-  compare: (a, b) => {
-    debugData(`Comparing ${JSON.stringify(a)} and ${JSON.stringify(b)}`);
+  const values = relevantSubfields.map(sf => sf.value).flat();
 
-    if (a.length === 0 || b.length === 0) {
-      debugData(`No language to compare`);
-      return 0;
-    }
+  return [...new Set(values)].sort();
+}
 
-    if (a.length === b.length && a.every((element, index) => element === b[index])) {
-      debugData(`All languages match`);
-      return 0.1;
-    }
-
-    const {matchingValues, possibleMatchValues, maxValues} = getMatchCounts(a, b);
-
-    if (matchingValues < 1) {
-      debug(`Both have languages, but none of these match.`);
-      return -1.0;
-    }
-    debug(`Both have languages, ${matchingValues}/${possibleMatchValues} valid languages match.`);
-    // ignore non-matches if there is mismatching amount of values
-    debug(`Possible matches: ${possibleMatchValues}/${maxValues}`);
-    //we give some kind of penalty for mismatching amount of values instead of simple divide?
-    const missingCount = maxValues - possibleMatchValues;
-    const misMatchCount = possibleMatchValues - matchingValues;
-    debug(`\t missing: ${missingCount}`);
-    debug(`\t mismatches: ${misMatchCount}`);
-
-    const penaltyForMissing = 0.02 * (maxValues - possibleMatchValues);
-    const penaltyForMisMatch = 0.05 * (possibleMatchValues - matchingValues);
-    debug(`\t points: penaltyForMissing: ${penaltyForMissing}`);
-    debug(`\t points: penaltyForMisMatch: ${penaltyForMisMatch}`);
-
-    const points = Number(Number(0.1 - penaltyForMisMatch - penaltyForMissing).toFixed(2));
-    debug(`Total points: ${points}`);
-
-    return points;
-  }
-});
+function getSharedValues(list1, list2) {
+  return list1.filter(val => list2.includes(val));
+}

--- a/src/match-detection/features/bib/language.js
+++ b/src/match-detection/features/bib/language.js
@@ -93,9 +93,9 @@ export default () => ({
       if (a041s.length === 1 && b041s.length === 1) {
         // The language codes are typically same between different sources. Incur a small penalty for differences though...
         const sourcePenalty = getSourceOfLanguageCode(a041s[0]) === getSourceOfLanguageCode(b041s[0]) ? 0.0 : -0.05;
-        const scoreInd1 = indicator1Penalty(a041s[0], b041s[0]);
-        debug(`\t Indicator penalty: '${scoreInd1}'`);
-        return sourcePenalty + scoreInd1 + compareLanguageCodeLists(getFieldsLanguageCodes(a041s[0]), getFieldsLanguageCodes(b041s[0]));
+        const mainPenalty = compareLanguageCodeLists(getFieldsLanguageCodes(a041s[0]), getFieldsLanguageCodes(b041s[0]));
+        const scoreInd1 = mainPenalty === 0.0 ? 0.0 : indicator1Penalty(a041s[0], b041s[0]);
+        return mainPenalty + sourcePenalty + scoreInd1;
       }
       // Things are already complicated (likely to pe penalized, so no nedd to worrty about language code sources, I daresay.
       return compareLanguageCodeLists(getLanguageCodesFrom041Fields(a), getLanguageCodesFrom041Fields(b));

--- a/src/match-detection/features/bib/standard-identifier-factory.js
+++ b/src/match-detection/features/bib/standard-identifier-factory.js
@@ -67,26 +67,20 @@ export default ({pattern, subfieldCodes, identifier, validIdentifierSubfieldCode
       return 0;
     }
 
-    const SCORE = 0.75;
-
     debugData(`A: ${JSON.stringify(a)}`);
     debugData(`B: ${JSON.stringify(b)}`);
 
-    const aValid = a.filter(sf => validIdentifierSubfieldCodes.includes(sf.code));
-    const bValid = b.filter(sf => validIdentifierSubfieldCodes.includes(sf.code));
-
-    if (aValid.some(asf => bValid.find(bsf => bsf.value === asf.value)) || bValid.some(bsf => aValid.find(asf => asf.value === bsf.value))) {
-      return SCORE;
-    }
 
     if (bothHaveValidIdentifiers()) {
-      return -SCORE;
-    }
-    // Not sure what to do if two invalid identifiers match... (There might me some stuff that causes false positives for some identifier types)
-    return 0.0;
-
-
-      /*
+      // Compare only valid identifiers, if both have valid idenfiers
+      const {maxValues, possibleMatchValues, matchingValues} = getValueCount(true);
+      if (matchingValues < 1) {
+        debug(`Both have valid standardidentifiers (${identifier}), but none of these match.`);
+        return -0.75;
+      }
+      debug(`Both have valid standardidentifiers (${identifier}), ${matchingValues}/${possibleMatchValues} valid identifiers match.`);
+      // ignore non-matches if there is mismatching amount of values
+      debug(`Possible matches: ${possibleMatchValues}/${maxValues}`);
       //we give some kind of penalty for mismatching amount of values instead of simple divide?
       const penaltyForMissing = 0.1 * (maxValues - possibleMatchValues);
       const penaltyForMisMatch = 0.2 * (possibleMatchValues - matchingValues);
@@ -95,15 +89,12 @@ export default ({pattern, subfieldCodes, identifier, validIdentifierSubfieldCode
 
       return 0.75 - penaltyForMisMatch - penaltyForMissing;
       //return matchingValues / possibleMatchValues * 0.75;
-      */
+    }
+    // If both do not have valid identifiers, compare all identifiers
+    const {maxValues, matchingValues} = getValueCount();
+    debug(`Both do NOT have valid standardidentifiers (${identifier}), ${matchingValues}/${maxValues} valid/invalid identifiers match.`);
 
-    /*
-    //// If both do not have valid identifiers, compare all identifiers
-    //const {maxValues, matchingValues} = getValueCount();
-    //debug(`Both do NOT have valid standardidentifiers (${identifier}), ${matchingValues}/${maxValues} valid/invalid identifiers match.`);
-
-    //return matchingValues / maxValues * 0.2;
-    */
+    return matchingValues / maxValues * 0.2;
 
     function bothHaveValidIdentifiers() {
       const aValues = a.filter(({code}) => validIdentifierSubfieldCodes.includes(code));

--- a/src/match-detection/features/bib/standard-identifier-factory.js
+++ b/src/match-detection/features/bib/standard-identifier-factory.js
@@ -67,20 +67,26 @@ export default ({pattern, subfieldCodes, identifier, validIdentifierSubfieldCode
       return 0;
     }
 
+    const SCORE = 0.75;
+
     debugData(`A: ${JSON.stringify(a)}`);
     debugData(`B: ${JSON.stringify(b)}`);
 
+    const aValid = a.filter(sf => validIdentifierSubfieldCodes.includes(sf.code));
+    const bValid = b.filter(sf => validIdentifierSubfieldCodes.includes(sf.code));
+
+    if (aValid.some(asf => bValid.find(bsf => bsf.value === asf.value)) || bValid.some(bsf => aValid.find(asf => asf.value === bsf.value))) {
+      return SCORE;
+    }
 
     if (bothHaveValidIdentifiers()) {
-      // Compare only valid identifiers, if both have valid idenfiers
-      const {maxValues, possibleMatchValues, matchingValues} = getValueCount(true);
-      if (matchingValues < 1) {
-        debug(`Both have valid standardidentifiers (${identifier}), but none of these match.`);
-        return -0.75;
-      }
-      debug(`Both have valid standardidentifiers (${identifier}), ${matchingValues}/${possibleMatchValues} valid identifiers match.`);
-      // ignore non-matches if there is mismatching amount of values
-      debug(`Possible matches: ${possibleMatchValues}/${maxValues}`);
+      return -SCORE;
+    }
+    // Not sure what to do if two invalid identifiers match... (There might me some stuff that causes false positives for some identifier types)
+    return 0.0;
+
+
+      /*
       //we give some kind of penalty for mismatching amount of values instead of simple divide?
       const penaltyForMissing = 0.1 * (maxValues - possibleMatchValues);
       const penaltyForMisMatch = 0.2 * (possibleMatchValues - matchingValues);
@@ -89,12 +95,15 @@ export default ({pattern, subfieldCodes, identifier, validIdentifierSubfieldCode
 
       return 0.75 - penaltyForMisMatch - penaltyForMissing;
       //return matchingValues / possibleMatchValues * 0.75;
-    }
-    // If both do not have valid identifiers, compare all identifiers
-    const {maxValues, matchingValues} = getValueCount();
-    debug(`Both do NOT have valid standardidentifiers (${identifier}), ${matchingValues}/${maxValues} valid/invalid identifiers match.`);
+      */
 
-    return matchingValues / maxValues * 0.2;
+    /*
+    //// If both do not have valid identifiers, compare all identifiers
+    //const {maxValues, matchingValues} = getValueCount();
+    //debug(`Both do NOT have valid standardidentifiers (${identifier}), ${matchingValues}/${maxValues} valid/invalid identifiers match.`);
+
+    //return matchingValues / maxValues * 0.2;
+    */
 
     function bothHaveValidIdentifiers() {
       const aValues = a.filter(({code}) => validIdentifierSubfieldCodes.includes(code));

--- a/src/match-detection/features/bib/title-version-original.js
+++ b/src/match-detection/features/bib/title-version-original.js
@@ -3,7 +3,7 @@ import createDebugLogger from 'debug';
 import naturalPkg from 'natural';
 const {LevenshteinDistance: leven} = naturalPkg;
 
-export default ({treshold = 10} = {}) => ({
+export default ({threshold = 10} = {}) => ({
   name: 'titleVersionOriginal',
   extract: ({record}) => {
     const title = getTitle();
@@ -38,7 +38,7 @@ export default ({treshold = 10} = {}) => ({
 
     debug(`'${a}' vs '${b}': Max length = ${maxLength}, distance = ${distance}, percentage = ${percentage}`);
 
-    if (percentage <= treshold) {
+    if (percentage <= threshold) {
       return 0.3;
     }
 

--- a/src/match-detection/features/bib/title.js
+++ b/src/match-detection/features/bib/title.js
@@ -7,7 +7,7 @@ const debug = createDebugLogger('@natlibfi/melinda-record-matching:match-detecti
 const debugData = debug.extend('data');
 
 
-export default ({treshold = 10} = {}) => ({
+export default ({threshold = 10} = {}) => ({
   name: 'Title',
   extract: ({record, recordExternal}) => {
     const label = recordExternal && recordExternal.label ? recordExternal.label : 'record';
@@ -19,8 +19,9 @@ export default ({treshold = 10} = {}) => ({
         // decompose unicode diacritics
         .normalize('NFD')
         // strip non-letters/numbers
-        // - note: combined with decomposing unicode diactics this normalizes both 'saa' and 'sää' as 'saa'
-        // - we could precompose the finnish letters back to avoid this
+        // - note: combined with decomposing unicode diacritics this normalizes both 'saa' and 'sää' as 'saa'
+        // - we could precompose the Finnish letters back to avoid this
+        // - see validator normalize-utf8-diacritics for details
         .replace(/[^\p{Letter}\p{Number}]/gu, '')
         .toLowerCase();
       debug(`${label}: titleString: ${titleAsNormalizedString}`);
@@ -56,7 +57,7 @@ export default ({treshold = 10} = {}) => ({
 
     debug(`'${a}' vs '${b}': Max length = ${maxLength}, distance = ${distance}, percentage = ${percentage}`);
 
-    if (percentage <= treshold) {
+    if (percentage <= threshold) {
       return 0.3;
     }
 

--- a/src/match-detection/index.js
+++ b/src/match-detection/index.js
@@ -4,13 +4,13 @@ import * as features from './features/index.js';
 
 export {features};
 
-export default ({strategy, treshold = 0.9}, returnStrategy = false, localSettings = {}) => ({recordA, recordB, recordAExternal = {}, recordBExternal = {}}) => {
+export default ({strategy, threshold = 0.8999}, returnStrategy = false, localSettings = {}) => ({recordA, recordB, recordAExternal = {}, recordBExternal = {}}) => {
   const minProbabilityQuantifier = 0.5;
 
   const debug = createDebugLogger('@natlibfi/melinda-record-matching:match-detection');
   const debugData = debug.extend('data');
 
-  debugData(`Strategy: ${JSON.stringify(strategy)}, Treshold: ${JSON.stringify(treshold)}, ReturnStrategy: ${JSON.stringify(returnStrategy)}`);
+  debugData(`Strategy: ${JSON.stringify(strategy)}, Threshold: ${JSON.stringify(threshold)}, ReturnStrategy: ${JSON.stringify(returnStrategy)}`);
   debugData(`Records: A: ${recordA}\nB: ${recordB}`);
   debug(`Externals: A: ${JSON.stringify(recordAExternal)}, B: ${JSON.stringify(recordBExternal)}`);
   // We could add here labels for records if we didn't get external labels
@@ -43,8 +43,8 @@ export default ({strategy, treshold = 0.9}, returnStrategy = false, localSetting
 
     if (similarityVector.some(v => v >= minProbabilityQuantifier)) {
       const probability = calculateProbability(similarityVector);
-      debug(`probability: ${probability} (Treshold: ${treshold})`);
-      return returnResult({match: probability >= treshold, probability});
+      debug(`probability: ${probability} (Threshold: ${threshold})`);
+      return returnResult({match: probability >= threshold, probability});
     }
 
     debugData(`No feature yielded minimum probability amount of points (${minProbabilityQuantifier})`);
@@ -58,7 +58,7 @@ export default ({strategy, treshold = 0.9}, returnStrategy = false, localSetting
   function returnResult(result) {
     if (returnStrategy) {
       debug(`Returning detection strategy with the result`);
-      const resultWithStrategy = {match: result.match, probability: result.probability, strategy: formatStrategy(strategy), treshold};
+      const resultWithStrategy = {match: result.match, probability: result.probability, strategy: formatStrategy(strategy), threshold};
       debugData(`${JSON.stringify(resultWithStrategy)}`);
       return resultWithStrategy;
     }

--- a/test-fixtures/candidate-search/query-list/bib/title/03/metadata.json
+++ b/test-fixtures/candidate-search/query-list/bib/title/03/metadata.json
@@ -1,7 +1,7 @@
 {
   "description": "Should generate title query including the subtitle (colon)",
   "type": "bibTitle",
-  "expectedQuery": ["dc.title=\"^E 18 ruusut hehkuvat periferio*\""],
+  "expectedQuery": ["dc.title=\"^E 18 ruusut hehkuvat periferioissa*\""],
   "inputRecord": {
     "leader": "02518cam a2200745zi 4500",
     "fields": [
@@ -20,7 +20,7 @@
           },
           {
             "code": "b",
-            "value": "ruusut hehkuvat periferioissa."
+            "value": "ruusut hehkuvat periferioissa ympäri vuoden."
           }
         ]
       }

--- a/test-fixtures/candidate-search/query-list/bib/title/04/metadata.json
+++ b/test-fixtures/candidate-search/query-list/bib/title/04/metadata.json
@@ -1,7 +1,7 @@
 {
   "description": "Should generate title query including the subtitle - no punctuation",
   "type": "bibTitle",
-  "expectedQuery": ["dc.title=\"^E 18 ruusut hehkuvat periferio*\""],
+  "expectedQuery": ["dc.title=\"^E 18 ruusut hehkuvat periferioissa*\""],
   "inputRecord": {
     "leader": "02518cam a2200745zi 4500",
     "fields": [
@@ -20,7 +20,7 @@
           },
           {
             "code": "b",
-            "value": "ruusut hehkuvat periferioissa."
+            "value": "ruusut hehkuvat periferioissa katkeraan loppuun."
           }
         ]
       }

--- a/test-fixtures/candidate-search/query-list/bib/title/05/metadata.json
+++ b/test-fixtures/candidate-search/query-list/bib/title/05/metadata.json
@@ -1,7 +1,7 @@
 {
   "description": "Should generate title query including the subtitle (punc: =)",
   "type": "bibTitle",
-  "expectedQuery": ["dc.title=\"^E 18 ruusut hehkuvat periferio*\""],
+  "expectedQuery": ["dc.title=\"^E 18 ruusut hehkuvat periferioissa*\""],
   "inputRecord": {
     "leader": "02518cam a2200745zi 4500",
     "fields": [
@@ -20,7 +20,7 @@
           },
           {
             "code": "b",
-            "value": "ruusut hehkuvat periferioissa."
+            "value": "ruusut hehkuvat periferioissa vuodesta toiseen."
           }
         ]
       }

--- a/test-fixtures/candidate-search/query-list/bib/title/19/metadata.json
+++ b/test-fixtures/candidate-search/query-list/bib/title/19/metadata.json
@@ -1,0 +1,27 @@
+{
+  "description": "Should not use word search for titles starting with a word starting with a boolean (*And*um)",
+  "skip": false,
+  "only": false,
+  "type": "bibTitle",
+  "expectedQuery": ["dc.title=\"^mighty have fallen*\""],
+  "inputRecord": {
+    "leader": "02518cam a2200745zi 4500",
+    "fields": [
+      {
+        "tag": "001",
+        "value": "000019643"
+      },
+      {
+        "tag": "245",
+        "ind1": " ",
+        "ind2": "4",
+        "subfields": [
+          {
+            "code": "a",
+            "value": "The mighty have fallen"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/test-fixtures/candidate-search/query-list/bib/titleAuthor/03/metadata.json
+++ b/test-fixtures/candidate-search/query-list/bib/titleAuthor/03/metadata.json
@@ -3,7 +3,7 @@
   "only": false,
   "skip": false,
   "type": "bibTitleAuthor",
-  "expectedQuery": ["dc.author=\"^Bazam*\" AND dc.title=\"^E 18 ruusut hehkuvat periferio*\""],
+  "expectedQuery": ["dc.author=\"^Bazam*\" AND dc.title=\"^E 18 ruusut hehkuvat periferioissa*\""],
   "inputRecord": {
     "leader": "02518cam a2200745zi 4500",
     "fields": [

--- a/test-fixtures/candidate-search/query-list/bib/titleAuthor/04/metadata.json
+++ b/test-fixtures/candidate-search/query-list/bib/titleAuthor/04/metadata.json
@@ -3,7 +3,7 @@
   "only": false,
   "skip": false,
   "type": "bibTitleAuthor",
-  "expectedQuery": ["dc.author=\"^Bazam*\" AND dc.title=\"^E 18 ruusut hehkuvat periferio*\""],
+  "expectedQuery": ["dc.author=\"^Bazam*\" AND dc.title=\"^E 18 ruusut hehkuvat periferioissa*\""],
   "inputRecord": {
     "leader": "02518cam a2200745zi 4500",
     "fields": [

--- a/test-fixtures/candidate-search/query-list/bib/titleAuthor/05/metadata.json
+++ b/test-fixtures/candidate-search/query-list/bib/titleAuthor/05/metadata.json
@@ -3,7 +3,7 @@
   "only": false,
   "skip": false,
   "type": "bibTitleAuthor",
-  "expectedQuery": ["dc.author=\"^Bazam*\" AND dc.title=\"^E 18 ruusut hehkuvat periferio*\""],
+  "expectedQuery": ["dc.author=\"^Bazam*\" AND dc.title=\"^E 18 ruusut hehkuvat periferioissa*\""],
   "inputRecord": {
     "leader": "02518cam a2200745zi 4500",
     "fields": [
@@ -36,7 +36,7 @@
           },
           {
             "code": "b",
-            "value": "ruusut hehkuvat periferioissa."
+            "value": "ruusut hehkuvat periferioissa ja katuojissa."
           }
         ]
       }

--- a/test-fixtures/index/10/expectedMatches.json
+++ b/test-fixtures/index/10/expectedMatches.json
@@ -5,7 +5,7 @@
       "Title",
       "ISBN"
     ],
-    "treshold": 0.9,
+    "threshold": 0.8999,
     "candidate": {
       "id": "000019641",
       "record": {

--- a/test-fixtures/index/10/expectedNonMatches.json
+++ b/test-fixtures/index/10/expectedNonMatches.json
@@ -5,7 +5,7 @@
       "Title",
       "ISBN"
     ],
-    "treshold": 0.9,
+    "threshold": 0.8999,
     "candidate": {
       "id": "000019642",
       "record": {

--- a/test-fixtures/match-detection/features/bib/isbn/01/metadata.json
+++ b/test-fixtures/match-detection/features/bib/isbn/01/metadata.json
@@ -1,0 +1,18 @@
+{
+  "description": "Matching invalid ISBN identifiers (so score is less than in test 02",
+  "feature": "isbn",
+  "type": "compare",
+  "expectedPoints": 0.5,
+  "featuresA": [
+    { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "a", "value": "9789526224771" }
+    ]}
+  ],
+  "featuresB": [
+    { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "a", "value": "9789526224771" }
+    ]}
+  ],
+  "skip": false,
+  "only": false
+}

--- a/test-fixtures/match-detection/features/bib/isbn/02/metadata.json
+++ b/test-fixtures/match-detection/features/bib/isbn/02/metadata.json
@@ -4,10 +4,14 @@
   "type": "compare",
   "expectedPoints": 0.75,
   "featuresA": [
-    { "code": "a", "value": "9789526224770" }
+    { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "a", "value": "9789526224770" }
+    ]}
   ],
   "featuresB": [
-    { "code": "a", "value": "9789526224770" }
+    { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "a", "value": "9789526224770" }
+    ]}
   ],
   "skip": false,
   "only": false

--- a/test-fixtures/match-detection/features/bib/isbn/03/metadata.json
+++ b/test-fixtures/match-detection/features/bib/isbn/03/metadata.json
@@ -2,12 +2,16 @@
   "description": "Comparison should return points for matching invalid ISBN identifiers",
   "feature": "isbn",
   "type": "compare",
-  "expectedPoints": 0.2,
+  "expectedPoints": 0.5,
   "featuresA": [
-    { "code": "z", "value": "978952622477X" }
+    { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "z", "value": "952622477X" }
+    ]}
   ],
   "featuresB": [
-    { "code": "z", "value": "978952622477X" }
+    { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "z", "value": "952622477X" }
+    ]}
   ],
   "skip": false,
   "only": false

--- a/test-fixtures/match-detection/features/bib/isbn/03/metadata.json
+++ b/test-fixtures/match-detection/features/bib/isbn/03/metadata.json
@@ -1,5 +1,5 @@
 {
-  "description": "Comparison should return points for matching invalid ISBN identifiers",
+  "description": "Comparison should return points for matching invalid ISBN identifiers (not as high as for valid identifiers though)",
   "feature": "isbn",
   "type": "compare",
   "expectedPoints": 0.5,

--- a/test-fixtures/match-detection/features/bib/isbn/04/metadata.json
+++ b/test-fixtures/match-detection/features/bib/isbn/04/metadata.json
@@ -4,10 +4,14 @@
   "type": "compare",
   "expectedPoints": -0.75,
   "featuresA": [
-    { "code": "a", "value": "978952622477X" }
+    { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "a", "value": "9789526224771" }
+    ]}
   ],
   "featuresB": [
-    { "code": "a", "value": "9789526224770" }
+    { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "a", "value": "9789526224770" }
+    ]}
   ],
   "skip": false,
   "only": false

--- a/test-fixtures/match-detection/features/bib/isbn/04/metadata.json
+++ b/test-fixtures/match-detection/features/bib/isbn/04/metadata.json
@@ -1,8 +1,8 @@
 {
-  "description": "Comparison should return minus points for mis-matching ISBN identifiers when there are no matching ISBNs",
+  "description": "One value is invalid, so it is not used when comparing valid ISBNs. As there's only one valid ISBN no score is given.",
   "feature": "isbn",
   "type": "compare",
-  "expectedPoints": -0.75,
+  "expectedPoints": 0.0,
   "featuresA": [
     { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [
       { "code": "a", "value": "9789526224771" }

--- a/test-fixtures/match-detection/features/bib/isbn/05/metadata.json
+++ b/test-fixtures/match-detection/features/bib/isbn/05/metadata.json
@@ -1,5 +1,5 @@
 {
-  "description": "Pair found. The non-pairing $a does not incur a penalty",
+  "description": "Pair found. The non-pairing $a does not incur a penalty as it is invalid",
   "feature": "isbn",
   "type": "compare",
   "expectedPoints": 0.75,

--- a/test-fixtures/match-detection/features/bib/isbn/05/metadata.json
+++ b/test-fixtures/match-detection/features/bib/isbn/05/metadata.json
@@ -1,14 +1,18 @@
 {
-  "description": "Comparison should give minor penalty for non-paired identifiers, when there's a match",
+  "description": "Pair found. The non-pairing $a does not incur a penalty",
   "feature": "isbn",
   "type": "compare",
-  "expectedPoints": 0.65,
+  "expectedPoints": 0.75,
   "featuresA": [
-    { "code": "a", "value": "978952622477X" },
-    { "code": "a", "value": "9789526224770" }
+    { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "a", "value": "978952622477X" },
+      { "code": "a", "value": "9789526224770" }
+    ]}
   ],
   "featuresB": [
-    { "code": "a", "value": "9789526224770" }
+    { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "a", "value": "9789526224770" }
+    ]}
   ],
   "skip": false,
   "only": false

--- a/test-fixtures/match-detection/features/bib/isbn/06/metadata.json
+++ b/test-fixtures/match-detection/features/bib/isbn/06/metadata.json
@@ -3,14 +3,18 @@
   "comment": "Values should be uniqued before comparing",
   "feature": "isbn",
   "type": "compare",
-  "expectedPoints": 0.55,
+  "expectedPoints": 0.75,
   "featuresA": [
-    { "code": "a", "value": "978952622477X" },
-    { "code": "a", "value": "978952622477X" }
+    { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [
+     { "code": "a", "value": "978952622477X" },
+     { "code": "a", "value": "978952622477X" }
+    ]}
   ],
   "featuresB": [
-    { "code": "a", "value": "9789526224770" },
-    { "code": "a", "value": "978952622477X" }
+    { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "a", "value": "9789526224770" },
+      { "code": "a", "value": "978952622477X" }
+    ]}
   ],
   "skip": false,
   "only": false

--- a/test-fixtures/match-detection/features/bib/isbn/06/metadata.json
+++ b/test-fixtures/match-detection/features/bib/isbn/06/metadata.json
@@ -1,19 +1,18 @@
 {
-  "description": "Comparison unique values and work same regardless of do we compare A to B or B to A. (Duplicate in A)",
+  "description": "Matching ISBN pair with one non-matching ISBN: reduce match point because of the non-match. Also use hyphens.",
   "comment": "Values should be uniqued before comparing",
   "feature": "isbn",
   "type": "compare",
-  "expectedPoints": 0.75,
+  "expectedPoints": 0.6,
   "featuresA": [
     { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [
-     { "code": "a", "value": "978952622477X" },
-     { "code": "a", "value": "978952622477X" }
+     { "code": "a", "value": "9789529487394" }
     ]}
   ],
   "featuresB": [
     { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [
       { "code": "a", "value": "9789526224770" },
-      { "code": "a", "value": "978952622477X" }
+      { "code": "a", "value": "978-952-94-8739-4" }
     ]}
   ],
   "skip": false,

--- a/test-fixtures/match-detection/features/bib/isbn/07/metadata.json
+++ b/test-fixtures/match-detection/features/bib/isbn/07/metadata.json
@@ -1,15 +1,21 @@
 {
-  "description": "Comparison should return points for matching invalid ISBN identifiers when there are no valid ISBNs at all",
+  "description": "The are invalid $z isbns that look decent and match. Since they are both $z give a slightlu lower score (0.5 instead of 0.75)",
   "feature": "isbn",
   "type": "compare",
-  "expectedPoints": 0.2,
+  "expectedPoints": 0.5,
   "featuresA": [
-    { "code": "z", "value": "978952622477X" },
-    { "code": "z", "value": "9789526224770" }
+    { "tag": "020", "subfields": [
+      { "code": "z", "value": "978952622477X" },
+      { "code": "z", "value": "9789526224770" }
+    ]}
   ],
   "featuresB": [
-    { "code": "z", "value": "9789526224770" },
-    { "code": "z", "value": "978952622477X" }
+    { "tag": "020", "subfields": [
+       { "code": "z", "value": "9789526224770" }
+    ]},
+    { "tag": "020", "subfields": [
+      { "code": "z", "value": "978952622477X" }
+    ]}
   ],
   "skip": false,
   "only": false

--- a/test-fixtures/match-detection/features/bib/isbn/07/metadata.json
+++ b/test-fixtures/match-detection/features/bib/isbn/07/metadata.json
@@ -1,20 +1,19 @@
 {
-  "description": "The are invalid $z isbns that look decent and match. Since they are both $z give a slightlu lower score (0.5 instead of 0.75)",
+  "description": "There's invalid $z isbns: a pair and a loner. Since they are both $z give a slightly lower score (0.5 instead of 0.75). No penalties for $z",
   "feature": "isbn",
   "type": "compare",
   "expectedPoints": 0.5,
   "featuresA": [
     { "tag": "020", "subfields": [
-      { "code": "z", "value": "978952622477X" },
       { "code": "z", "value": "9789526224770" }
     ]}
   ],
   "featuresB": [
     { "tag": "020", "subfields": [
-       { "code": "z", "value": "9789526224770" }
+      { "code": "z", "value": "9789526224770" }
     ]},
     { "tag": "020", "subfields": [
-      { "code": "z", "value": "978952622477X" }
+      { "code": "z", "value": "9789526224771" }
     ]}
   ],
   "skip": false,

--- a/test-fixtures/match-detection/features/bib/isbn/08/metadata.json
+++ b/test-fixtures/match-detection/features/bib/isbn/08/metadata.json
@@ -2,16 +2,14 @@
   "description": "Valid isbn matches an invalid isbn of another record: looks fine to me",
   "feature": "isbn",
   "type": "compare",
-  "expectedPoints": 0.75,
+  "expectedPoints": 0.0,
   "featuresA": [
     { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [
-      { "code": "z", "value": "978952622477X" },
-      { "code": "z", "value": "9789526224770" }
+      { "code": "z", "value": "978952622477X" }
     ]}
   ],
   "featuresB": [
     { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [
-      { "code": "a", "value": "9789526224770" },
       { "code": "a", "value": "978952622477X" }
     ]}
   ],

--- a/test-fixtures/match-detection/features/bib/isbn/08/metadata.json
+++ b/test-fixtures/match-detection/features/bib/isbn/08/metadata.json
@@ -1,15 +1,19 @@
 {
-  "description": "Comparison should return points for matching invalid ISBN identifiers when there are valid isbns just in one record",
+  "description": "Valid isbn matches an invalid isbn of another record: looks fine to me",
   "feature": "isbn",
   "type": "compare",
-  "expectedPoints": 0.2,
+  "expectedPoints": 0.75,
   "featuresA": [
-    { "code": "z", "value": "978952622477X" },
-    { "code": "z", "value": "9789526224770" }
+    { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "z", "value": "978952622477X" },
+      { "code": "z", "value": "9789526224770" }
+    ]}
   ],
   "featuresB": [
-    { "code": "a", "value": "9789526224770" },
-    { "code": "a", "value": "978952622477X" }
+    { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "a", "value": "9789526224770" },
+      { "code": "a", "value": "978952622477X" }
+    ]}
   ],
   "skip": false,
   "only": false

--- a/test-fixtures/match-detection/features/bib/isbn/08/metadata.json
+++ b/test-fixtures/match-detection/features/bib/isbn/08/metadata.json
@@ -1,5 +1,5 @@
 {
-  "description": "Valid isbn matches an invalid isbn of another record: looks fine to me",
+  "description": "Invalid isbn's don't count: score is 0",
   "feature": "isbn",
   "type": "compare",
   "expectedPoints": 0.0,

--- a/test-fixtures/match-detection/features/bib/isbn/09/metadata.json
+++ b/test-fixtures/match-detection/features/bib/isbn/09/metadata.json
@@ -1,15 +1,18 @@
 {
-  "description": "Comparison should return minus points if there are valid and invalid ISBN:s and valid ISBNs do not match",
+  "description": "Two values match, but they don't look like isbns, so no points for that. Both have $a -> penalty (might be too tough)",
   "feature": "isbn",
   "type": "compare",
   "expectedPoints": -0.75,
   "featuresA": [
-    { "code": "a", "value": "978952622477X" },
-    { "code": "z", "value": "9789526224770" }
+    { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "a", "value": "978952622477X" }
+    ]}
   ],
   "featuresB": [
-    { "code": "a", "value": "9789526224770" },
-    { "code": "z", "value": "978952622477X" }
+    { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "a", "value": "9789526224770" },
+      { "code": "z", "value": "978952622477X" }
+    ]}
   ],
   "skip": false,
   "only": false

--- a/test-fixtures/match-detection/features/bib/isbn/09/metadata.json
+++ b/test-fixtures/match-detection/features/bib/isbn/09/metadata.json
@@ -1,8 +1,8 @@
 {
-  "description": "Two values match, but they don't look like isbns, so no points for that. Both have $a -> penalty (might be too tough)",
+  "description": "Invalid ISBNs and canceled ISBN are meaningless here",
   "feature": "isbn",
   "type": "compare",
-  "expectedPoints": -0.75,
+  "expectedPoints": 0.0,
   "featuresA": [
     { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [
       { "code": "a", "value": "978952622477X" }

--- a/test-fixtures/match-detection/features/bib/isbn/10/metadata.json
+++ b/test-fixtures/match-detection/features/bib/isbn/10/metadata.json
@@ -3,14 +3,18 @@
   "comment": "Values should be uniqued before comparing",
   "feature": "isbn",
   "type": "compare",
-  "expectedPoints": 0.55,
+  "expectedPoints": 0.75,
   "featuresA": [
-    { "code": "a", "value": "9789526224770" },
-    { "code": "a", "value": "978952622477X" }
+    { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "a", "value": "9789526224770" },
+      { "code": "a", "value": "978952622477X" }
+    ]}
   ],
   "featuresB": [
-    { "code": "a", "value": "978952622477X" },
-    { "code": "a", "value": "978952622477X" }
+    { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "a", "value": "978952622477X" },
+      { "code": "a", "value": "978952622477X" }
+    ]}
   ],
   "skip": false,
   "only": false

--- a/test-fixtures/match-detection/features/bib/isbn/10/metadata.json
+++ b/test-fixtures/match-detection/features/bib/isbn/10/metadata.json
@@ -1,19 +1,19 @@
 {
-  "description": "Comparison unique values and work same regardless of do we compare A to B or B to A. (Duplicate in B)",
+  "description": "Match x 2. Check mainly that uniq works.",
   "comment": "Values should be uniqued before comparing",
   "feature": "isbn",
   "type": "compare",
   "expectedPoints": 0.75,
   "featuresA": [
     { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [
-      { "code": "a", "value": "9789526224770" },
-      { "code": "a", "value": "978952622477X" }
+      { "code": "a", "value": "978-1-5400-3029-0" },
+      { "code": "a", "value": "978-1-5400-3029-0" }
     ]}
   ],
   "featuresB": [
     { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [
-      { "code": "a", "value": "978952622477X" },
-      { "code": "a", "value": "978952622477X" }
+      { "code": "a", "value": "9781540030290" },
+      { "code": "a", "value": "97815400-30290" }
     ]}
   ],
   "skip": false,

--- a/test-fixtures/match-detection/features/bib/isbn/11/metadata.json
+++ b/test-fixtures/match-detection/features/bib/isbn/11/metadata.json
@@ -1,15 +1,17 @@
 {
-  "description": "Comparison should give a penalty for each additional mismatch when there's a match",
+  "description": "Comparison should *not* give a penalty for each additional mismatch when there's a match",
   "feature": "isbn",
   "type": "compare",
-  "expectedPoints": 0.55,
+  "expectedPoints": 0.75,
   "featuresA": [
-    { "code": "a", "value": "978952622477X" },
-    { "code": "a", "value": "9789526224770" }
+    { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [ { "code": "a", "value": "978952622477X" } ] },
+    { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [ { "code": "a", "value": "9789526224770" } ] }
   ],
   "featuresB": [
-    { "code": "a", "value": "978952622477X" },
-    { "code": "a", "value": "9789526224771" }
+    { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "a", "value": "978952622477X" },
+      { "code": "a", "value": "9789526224771" }
+    ]}
   ],
   "skip": false,
   "only": false

--- a/test-fixtures/match-detection/features/bib/isbn/11/metadata.json
+++ b/test-fixtures/match-detection/features/bib/isbn/11/metadata.json
@@ -1,15 +1,16 @@
 {
-  "description": "Comparison should *not* give a penalty for each additional mismatch when there's a match",
+  "description": "ISBN match (0.75) is reduced by factor 0.8 as there's *one* pairless legal ISBN (the *771 is considered invalid)",
+  "comment": "978952622477X is invalid as isbn3 never ends in X",
   "feature": "isbn",
   "type": "compare",
-  "expectedPoints": 0.75,
+  "expectedPoints": 0.6,
   "featuresA": [
-    { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [ { "code": "a", "value": "978952622477X" } ] },
+    { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [ { "code": "a", "value": "978-951-29-5671-5" } ] },
     { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [ { "code": "a", "value": "9789526224770" } ] }
   ],
   "featuresB": [
     { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [
-      { "code": "a", "value": "978952622477X" },
+      { "code": "a", "value": "978-951-29-5671-5" },
       { "code": "a", "value": "9789526224771" }
     ]}
   ],

--- a/test-fixtures/match-detection/features/bib/isbn/12/metadata.json
+++ b/test-fixtures/match-detection/features/bib/isbn/12/metadata.json
@@ -1,0 +1,19 @@
+{
+  "description": "ISBN match (0.75) is reduced by factor 0.8 *twice* as there are two non-matching ISBNs",
+  "comment": "978952622477X is invalid as isbn3 never ends in X",
+  "feature": "isbn",
+  "type": "compare",
+  "expectedPoints": 0.48,
+  "featuresA": [
+    { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [ { "code": "a", "value": "978-951-29-5671-5" } ] },
+    { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [ { "code": "a", "value": "9789526224770" } ] }
+  ],
+  "featuresB": [
+    { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "a", "value": "978-951-29-5671-5" },
+      { "code": "a", "value": "978-951-672-276-7" }
+    ]}
+  ],
+  "skip": false,
+  "only": false
+}

--- a/test-fixtures/match-detection/features/bib/isbn/51/metadata.json
+++ b/test-fixtures/match-detection/features/bib/isbn/51/metadata.json
@@ -3,12 +3,52 @@
   "feature": "isbn",
   "type": "extract",
   "expectedFeatures": [
-    {
-      "code": "a", "value": "9789513148362"
-    },
-    {
-      "code": "a", "value": "9789526224770"
-    }
+          {
+        "tag": "020",
+        "ind1": " ",
+        "ind2": " ",
+        "subfields": [
+          {
+            "code": "a",
+            "value": "978-951-31-4836-2"
+          },
+          {
+            "code": "q",
+            "value": "PDF"
+          }
+        ]
+      },
+      {
+        "tag": "020",
+        "ind1": " ",
+        "ind2": " ",
+        "subfields": [
+          {
+            "code": "a",
+            "value": "978-952-62-2477-0"
+          },
+          {
+            "code": "q",
+            "value": "PDF"
+          }
+        ]
+      },
+      {
+        "tag": "020",
+        "ind1": " ",
+        "ind2": " ",
+        "subfields": [
+          {
+            "code": "a",
+            "value": "9789526224770"
+          },
+          {
+            "code": "q",
+            "value": "PDF"
+          }
+        ]
+      }
+
   ],
   "inputRecord": {
     "leader": "02518cam a2200745zi 4500",

--- a/test-fixtures/match-detection/features/bib/isbn/52/metadata.json
+++ b/test-fixtures/match-detection/features/bib/isbn/52/metadata.json
@@ -3,9 +3,21 @@
   "feature": "isbn",
   "type": "extract",
   "expectedFeatures": [
-    {
-      "code": "a", "value": "9789526224770"
-    }
+        {
+        "tag": "020",
+        "ind1": " ",
+        "ind2": " ",
+        "subfields": [
+          {
+            "code": "a",
+            "value": "978-952-62-2477-0"
+          },
+          {
+            "code": "q",
+            "value": "PDF"
+          }
+        ]
+      }
   ],
   "inputRecord": {
     "leader": "02518cam a2200745zi 4500",

--- a/test-fixtures/match-detection/features/bib/isbn/53/metadata.json
+++ b/test-fixtures/match-detection/features/bib/isbn/53/metadata.json
@@ -3,9 +3,21 @@
   "feature": "isbn",
   "type": "extract",
   "expectedFeatures": [
-    {
-      "code": "z", "value": "9789526224771"
-    }
+          {
+        "tag": "020",
+        "ind1": " ",
+        "ind2": " ",
+        "subfields": [
+          {
+            "code": "a",
+            "value": "9789526224771"
+          },
+          {
+            "code": "q",
+            "value": "PDF"
+          }
+        ]
+      }
   ],
   "inputRecord": {
     "leader": "02518cam a2200745zi 4500",

--- a/test-fixtures/match-detection/features/bib/isbn/54/metadata.json
+++ b/test-fixtures/match-detection/features/bib/isbn/54/metadata.json
@@ -3,9 +3,10 @@
   "feature": "isbn",
   "type": "extract",
   "expectedFeatures": [
-    {
-      "code": "a", "value": "9789526224770"
-    }
+    { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "a", "value": "952-62-2477-9" },
+      { "code": "q", "value": "PDF" }
+    ]}
   ],
   "inputRecord": {
     "leader": "02518cam a2200745zi 4500",

--- a/test-fixtures/match-detection/features/bib/isbn/55/metadata.json
+++ b/test-fixtures/match-detection/features/bib/isbn/55/metadata.json
@@ -3,15 +3,15 @@
   "feature": "isbn",
   "type": "extract",
   "expectedFeatures": [
-    {
-      "code": "a", "value": "9789526224770"
-    },
-    {
-      "code": "z", "value": "9789526224771"
-    },
-    {
-      "code": "z", "value": "9789526224770"
-    }
+    { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "a", "value": "978-952-62-2477-0" },
+      { "code": "z", "value": "978-952-62-2477-1" },
+      { "code": "q", "value": "PDF" }
+    ]},
+    { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "z", "value": "978-952-62-2477-0" },
+      { "code": "q", "value": "PDF" }
+    ]}
   ],
   "inputRecord": {
     "leader": "02518cam a2200745zi 4500",

--- a/test-fixtures/match-detection/features/bib/isbn/56/metadata.json
+++ b/test-fixtures/match-detection/features/bib/isbn/56/metadata.json
@@ -3,12 +3,30 @@
   "feature": "isbn",
   "type": "extract",
   "expectedFeatures": [
-    {
-      "code": "a", "value": "9789526224770"
-    },
-    {
-      "code": "a", "value": "9789513148362"
-    }
+          {
+        "tag": "020", "ind1": " ", "ind2": " ", "subfields": [
+          {
+            "code": "a",
+            "value": "978-952-62-2477-0"
+          },
+          {
+            "code": "q",
+            "value": "PDF"
+          }
+        ]
+      },
+            {
+        "tag": "020", "ind1": " ", "ind2": " ", "subfields": [
+          {
+            "code": "a",
+            "value": "978-951-31-4836-2"
+          },
+          {
+            "code": "q",
+            "value": "PDF"
+          }
+        ]
+      }
   ],
   "inputRecord": {
     "leader": "02518cam a2200745zi 4500",

--- a/test-fixtures/match-detection/features/bib/isbn/57/metadata.json
+++ b/test-fixtures/match-detection/features/bib/isbn/57/metadata.json
@@ -2,14 +2,13 @@
   "description": "Should extract valid and invalid ISBNs identifiers from the same field",
   "feature": "isbn",
   "type": "extract",
-  "expectedFeatures": [
-    {
-      "code": "a", "value": "9789526224770"
-    },
-    {
-      "code": "z", "value": "9789513148362"
-    }
-  ],
+  "expectedFeatures": [{
+    "tag": "020", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "a", "value": "978-952-62-2477-0" },
+      { "code": "z", "value": "978-951-31-4836-2" },
+      { "code": "q", "value": "PDF" }
+    ]
+  }],
   "inputRecord": {
     "leader": "02518cam a2200745zi 4500",
     "fields": [

--- a/test-fixtures/match-detection/features/bib/isbn/58/metadata.json
+++ b/test-fixtures/match-detection/features/bib/isbn/58/metadata.json
@@ -3,8 +3,10 @@
   "feature": "isbn",
   "type": "extract",
   "expectedFeatures": [
-    {
-      "code": "z", "value": "95262247791"
+    { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [
+        { "code": "a", "value": "952-62-2477-91" },
+        { "code": "q", "value": "PDF" }
+      ]
     }
   ],
   "inputRecord": {

--- a/test-fixtures/match-detection/features/bib/issn/01/metadata.json
+++ b/test-fixtures/match-detection/features/bib/issn/01/metadata.json
@@ -1,9 +1,9 @@
 {
-  "description": "Should extract ISSN identifiers from 022",
+  "description": "Should extract ISSN identifiers from 773 (since melinda UI commons isComponentRecord() function",
   "feature": "issn",
   "type": "extract",
   "expectedFeatures": [
-    "2049-3630"
+    "1234-5678"
   ],
   "inputRecord": {
     "leader": "02518cam a2200745zi 4500",

--- a/test-fixtures/match-detection/features/bib/issn/01/metadata.json
+++ b/test-fixtures/match-detection/features/bib/issn/01/metadata.json
@@ -1,11 +1,9 @@
 {
-  "description": "Should extract ISSN identifiers",
+  "description": "Should extract ISSN identifiers from 022",
   "feature": "issn",
   "type": "extract",
   "expectedFeatures": [
-    {
-      "code": "a", "value": "20493630"
-    }
+    "2049-3630"
   ],
   "inputRecord": {
     "leader": "02518cam a2200745zi 4500",
@@ -21,8 +19,13 @@
         "subfields": [
           {
             "code": "a",
-            "value": "2049-3630"
+            "value": "2049-3630 foo bar"
           }
+        ]
+      },
+      { "tag": "773", "ind1": " ", "ind2": " ", "subfields": [
+          { "code": "t", "value": "Tuttelintiire." },
+          { "code": "x", "value": "1234-5678"}
         ]
       }
     ]

--- a/test-fixtures/match-detection/features/bib/issn/02/metadata.json
+++ b/test-fixtures/match-detection/features/bib/issn/02/metadata.json
@@ -1,12 +1,12 @@
 {
-  "description": "Comparison should return points for matching standard identifiers",
-  "feature": "isbn",
+  "description": "Comparison should return penalty points for non-matching standard identifiers",
+  "feature": "issn",
   "type": "compare",
-  "expectedPoints": 0.75,
+  "expectedPoints": -0.2,
   "featuresA": [
-    { "code": "a", "value": "20493630" }
+    "2049-3630"
   ],
   "featuresB": [
-    { "code": "a", "value": "20493630" }
+    "2049-363X"
   ]
 }

--- a/test-fixtures/match-detection/features/bib/issn/03/metadata.json
+++ b/test-fixtures/match-detection/features/bib/issn/03/metadata.json
@@ -4,9 +4,9 @@
   "type": "compare",
   "expectedPoints": 0.2,
   "featuresA": [
-    { "code": "z", "value": "2049363X" }
+    "2049-363X"
   ],
   "featuresB": [
-    { "code": "z", "value": "2049363X" }
+    "2049-363X"
   ]
 }

--- a/test-fixtures/match-detection/features/bib/issn/11/metadata.json
+++ b/test-fixtures/match-detection/features/bib/issn/11/metadata.json
@@ -1,0 +1,23 @@
+{
+  "description": "Should extract ISSN identifiers from 773$x",
+  "feature": "issn",
+  "type": "extract",
+  "expectedFeatures": [
+    "1234-5678"
+  ],
+  "inputRecord": {
+    "leader": "02518caa a2200745zi 4500",
+    "fields": [
+      { "tag": "001", "value": "000019643" },
+      { "tag": "022", "ind1": " ", "ind2": " ", "subfields": [
+          { "code": "a", "value": "2049-3630 foo bar" }
+        ]
+      },
+      { "tag": "773", "ind1": " ", "ind2": " ", "subfields": [
+          { "code": "t", "value": "Tuttelintiire." },
+          { "code": "x", "value": "1234-5678"}
+        ]
+      }
+    ]
+  }
+}

--- a/test-fixtures/match-detection/features/bib/language/01/metadata.json
+++ b/test-fixtures/match-detection/features/bib/language/01/metadata.json
@@ -1,30 +1,20 @@
 {
-  "description": "Should extract language",
+  "description": "Preprocess Sami language",
+  "skip": false,
   "feature": "language",
   "type": "extract",
-  "expectedFeatures": ["fin"],
   "inputRecord": {
     "leader": "02518cam a2200745zi 4500",
     "fields": [
-      {
-        "tag": "001",
-        "value": "000019643"
-      },
-      {
-        "tag": "008",
-        "value": "831017s1983    fi ||||||||||||||||bfin||"
-      },
-      {
-        "tag": "041",
-        "ind1": "0",
-        "ind2": " ",
-        "subfields": [
-          {
-            "code": "a",
-            "value": "fin"
-          }
-        ]
-      }
+      { "tag": "008", "value": "831017s1983    fi |||||||||||||||||sma||" },
+      { "tag": "041", "ind1": "0", "ind2": " ", "subfields": [ { "code": "a", "value": "sma" }] }
     ]
-  }
+  },
+  "expectedFeatures": [ {
+    "leader": "02518cam a2200745zi 4500",
+    "fields": [
+      { "tag": "008", "value": "831017s1983    fi |||||||||||||||||smi||" },
+      { "tag": "041", "ind1": "0", "ind2": " ", "subfields": [ { "code": "a", "value": "smi" }, { "code": "a", "value": "sma" }] }
+    ]
+  }, "record" ]
 }

--- a/test-fixtures/match-detection/features/bib/language/02/metadata.json
+++ b/test-fixtures/match-detection/features/bib/language/02/metadata.json
@@ -1,32 +1,20 @@
 {
-  "description": "Should extract language from 041 (||| in 008)",
+  "description": "Test zxx removal in 041 fields",
   "feature": "language",
   "type": "extract",
-  "expectedFeatures": ["fin"],
   "inputRecord": {
     "leader": "02518cam a2200745zi 4500",
     "fields": [
-      {
-        "tag": "001",
-        "value": "000019643"
-      },
-      {
-        "tag": "008",
-        "value": "831017s1983    fi ||||||||||||||||b|||||"
-      },
-      {
-        "tag": "041",
-        "ind1": "0",
-        "ind2": " ",
-        "subfields": [
-          {
-            "code": "a",
-            "value": "fin"
-          }
-        ]
-      }
+      { "tag": "008", "value": "831017s1983    fi |||||||||||||||||foo||" },
+      { "tag": "041", "ind1": "0", "ind2": " ", "subfields": [ { "code": "a", "value": "foo" }, { "code": "a", "value": "zxx" }] },
+      { "tag": "041", "ind1": "0", "ind2": " ", "subfields": [ { "code": "a", "value": "zxx" }] }
     ]
   },
-  "skip": false,
-  "only": false
+  "expectedFeatures": [ {
+    "leader": "02518cam a2200745zi 4500",
+    "fields": [
+      { "tag": "008", "value": "831017s1983    fi |||||||||||||||||foo||" },
+      { "tag": "041", "ind1": "0", "ind2": " ", "subfields": [ { "code": "a", "value": "foo" }] }
+    ]
+  }, "record" ]
 }

--- a/test-fixtures/match-detection/features/bib/language/03/metadata.json
+++ b/test-fixtures/match-detection/features/bib/language/03/metadata.json
@@ -1,5 +1,6 @@
 {
-  "description": "Should extract language from 008",
+  "description": "Should extract language from 008 (DEPRECATED! Remove or replace eventually!)",
+  "skip": true,
   "feature": "language",
   "type": "extract",
   "expectedFeatures": ["fin"],

--- a/test-fixtures/match-detection/features/bib/language/04/metadata.json
+++ b/test-fixtures/match-detection/features/bib/language/04/metadata.json
@@ -1,0 +1,21 @@
+{
+  "description": "Comparison should return points for matching languages",
+  "feature": "language",
+  "type": "compare",
+  "expectedPoints": 0.1,
+  "featuresA": [{
+    "fields": [
+      {"tag": "041", "ind1": " ", "ind2": " ", "subfields": [
+        {"code": "a", "value": "fin"}
+      ]}
+    ]
+  }, "A"],
+  "featuresB": [{
+    "fields": [
+      {"tag": "041", "ind1": " ", "ind2": " ", "subfields": [
+        {"code": "a", "value": "fin"}
+      ]}
+
+    ]
+  }, "B"]
+}

--- a/test-fixtures/match-detection/features/bib/language/05/04/metadata.json
+++ b/test-fixtures/match-detection/features/bib/language/05/04/metadata.json
@@ -1,8 +1,0 @@
-{
-  "description": "Comparison should return points for matching languages",
-  "feature": "language",
-  "type": "compare",
-  "expectedPoints": 0.1,
-  "featuresA": ["fin"],
-  "featuresB": ["fin"]
-}

--- a/test-fixtures/match-detection/features/bib/language/05/metadata.json
+++ b/test-fixtures/match-detection/features/bib/language/05/metadata.json
@@ -3,6 +3,19 @@
   "feature": "language",
   "type": "compare",
   "expectedPoints": -1.0,
-  "featuresA": ["eng"],
-  "featuresB": ["fin"]
+  "featuresA": [{
+    "fields": [
+      {"tag": "041", "ind1": " ", "ind2": " ", "subfields": [
+        {"code": "a", "value": "eng"}
+      ]}
+    ]
+  }, "A"],
+  "featuresB": [{
+    "fields": [
+      {"tag": "041", "ind1": " ", "ind2": " ", "subfields": [
+        {"code": "a", "value": "fin"}
+      ]}
+
+    ]
+  }, "B"]
 }

--- a/test-fixtures/match-detection/features/bib/language/06/metadata.json
+++ b/test-fixtures/match-detection/features/bib/language/06/metadata.json
@@ -1,5 +1,6 @@
 {
-  "description": "Should not extract language if there's no f008 or f041",
+  "description": "Should not extract language if there's no f008 or f041 (DEPRECATED! Remove or replace with another test!)",
+  "skip": true,
   "feature": "language",
   "type": "extract",
   "expectedFeatures": [],

--- a/test-fixtures/match-detection/features/bib/language/07/metadata.json
+++ b/test-fixtures/match-detection/features/bib/language/07/metadata.json
@@ -1,8 +1,16 @@
 {
-  "description": "Comparison should not return points for missing language in both",
+  "description": "Comparison should not return points for missing language in both. (040$b refers to the cataloging language)",
   "feature": "language",
   "type": "compare",
   "expectedPoints": 0,
-  "featuresA": [],
-  "featuresB": []
+  "featuresA": [{
+    "fields": [
+      {"tag": "040", "ind1": " ", "ind2": " ", "subfields": [{"code": "b", "value": "fin"}]}
+    ]
+  }, "A"],
+  "featuresB": [{
+    "fields": [
+      {"tag": "040", "ind1": " ", "ind2": " ", "subfields": [{"code": "b", "value": "fin"}]}
+    ]
+  }, "B"]
 }

--- a/test-fixtures/match-detection/features/bib/language/09/metadata.json
+++ b/test-fixtures/match-detection/features/bib/language/09/metadata.json
@@ -1,5 +1,6 @@
 {
-  "description": "Should extract all languages and sort them",
+  "description": "Should extract all languages and sort them (DEPRECATED! Remove eventually!)",
+  "skip": true,
   "feature": "language",
   "type": "extract",
   "expectedFeatures": ["eng", "fin", "swe"],

--- a/test-fixtures/match-detection/features/bib/language/10/metadata.json
+++ b/test-fixtures/match-detection/features/bib/language/10/metadata.json
@@ -1,5 +1,6 @@
 {
-  "description": "Should extract language from 041 (^^^ in f008)",
+  "description": "Should extract language from 041 (^^^ in f008) (DEPRECATED! Remove eventually!)",
+  "skip": true,
   "feature": "language",
   "type": "extract",
   "expectedFeatures": ["fin"],

--- a/test-fixtures/match-detection/features/bib/language/11/metadata.json
+++ b/test-fixtures/match-detection/features/bib/language/11/metadata.json
@@ -1,5 +1,6 @@
 {
-  "description": "Should extract language from 041 ('   ' in f008)",
+  "description": "Should extract language from 041 ('   ' in f008) (DEPRECATED! Remove eventually!)",
+  "skip": true,
   "feature": "language",
   "type": "extract",
   "expectedFeatures": ["fin"],

--- a/test-fixtures/match-detection/features/bib/language/12/metadata.json
+++ b/test-fixtures/match-detection/features/bib/language/12/metadata.json
@@ -1,5 +1,6 @@
 {
   "description": "Should extract language from 041 (no f008)",
+  "skip": true,
   "feature": "language",
   "type": "extract",
   "expectedFeatures": ["fin"],

--- a/test-fixtures/match-detection/features/bib/language/13/metadata.json
+++ b/test-fixtures/match-detection/features/bib/language/13/metadata.json
@@ -1,5 +1,6 @@
 {
-  "description": "Should extract language from f041 d",
+  "description": "Should extract language from f041 d. (DEPRECATED! Remove eventually!)",
+  "skip": true,
   "feature": "language",
   "type": "extract",
   "expectedFeatures": ["fin"],

--- a/test-fixtures/match-detection/features/bib/language/14/metadata.json
+++ b/test-fixtures/match-detection/features/bib/language/14/metadata.json
@@ -1,47 +1,24 @@
 {
-  "description": "Should not extract language from 041 if the language code is not MARC 21 (ind2 is not ' ') ",
+  "description": "ind1 check: '#' does not incur in penalty. 'und' vs 'eng' is fine (no points nor penalty for that)",
   "feature": "language",
-  "type": "extract",
-  "expectedFeatures": [
-    "swe"
-  ],
-  "inputRecord": {
-    "leader": "02518cam a2200745zi 4500",
+  "type": "compare",
+  "expectedPoints": 0.0,
+
+    "featuresA": [{
     "fields": [
-      {
-        "tag": "001",
-        "value": "000019643"
-      },
-      {
-        "tag": "008",
-        "value": "831017s1983    fi ||||||||||||||||b|||||"
-      },
-      {
-        "tag": "041",
-        "ind1": "0",
-        "ind2": "7",
-        "subfields": [
-          {
-            "code": "a",
-            "value": "foob"
-          },
-          {
-            "code": "2",
-            "value": "bar"
-          }
-        ]
-      },
-      {
-        "tag": "041",
-        "ind1": "0",
-        "ind2": " ",
-        "subfields": [
-          {
-            "code": "d",
-            "value": "swe"
-          }
-        ]
-      }
+      {"tag": "041", "ind1": " ", "ind2": " ", "subfields": [
+        {"code": "a", "value": "und"}
+      ]}
     ]
-  }
+  }, "A"],
+  "featuresB": [{
+    "fields": [
+      {"tag": "041", "ind1": "0", "ind2": " ", "subfields": [
+        {"code": "a", "value": "eng"}
+      ]}
+
+    ]
+  }, "B"],
+  "skip": false,
+  "only": false
 }

--- a/test-fixtures/match-detection/features/bib/language/15/metadata.json
+++ b/test-fixtures/match-detection/features/bib/language/15/metadata.json
@@ -1,35 +1,25 @@
 {
-  "description": "INACTIVE: Should not extract language if there are both 008 and 041 and they do not have a common language",
+  "description": "same language code 'eng' (+0.1) but with a language code source penalty (-0.05).",
   "feature": "language",
-  "type": "extract",
-  "expectedFeatures": [],
-  "inputRecord": {
-    "leader": "02518cam a2200745zi 4500",
+  "type": "compare",
+  "expectedPoints": 0.05,
+
+    "featuresA": [{
     "fields": [
-      {
-        "tag": "001",
-        "value": "000019643"
-      },
-      {
-        "tag": "008",
-        "value": "831017s1983    fi ||||||||||||||||bfin||"
-      },
-      {
-        "tag": "041",
-        "ind1": "0",
-        "ind2": " ",
-        "subfields": [
-          {
-            "code": "a",
-            "value": "eng"
-          },
-          {
-            "code": "a",
-            "value": "swe"
-          }
-        ]
-      }
+      {"tag": "041", "ind1": " ", "ind2": "7", "subfields": [
+        {"code": "a", "value": "eng"},
+        {"code": "2", "value": "ISO639-2"}
+      ]}
     ]
-  },
-  "skip": true
+  }, "A"],
+  "featuresB": [{
+    "fields": [
+      {"tag": "041", "ind1": " ", "ind2": " ", "subfields": [
+        {"code": "a", "value": "eng"}
+      ]}
+
+    ]
+  }, "B"],
+  "skip": false,
+  "only": false
 }

--- a/test-fixtures/match-detection/features/bib/language/16/metadata.json
+++ b/test-fixtures/match-detection/features/bib/language/16/metadata.json
@@ -1,38 +1,25 @@
 {
-  "description": "Should extract all languages and sort and unique them",
+  "description": "ind1 check: same language 'eng' (+0.1) but translation vs non-translation (-0.1). Is the penalty too light?",
   "feature": "language",
-  "type": "extract",
-  "expectedFeatures": ["eng", "fin", "swe"],
-  "inputRecord": {
-    "leader": "02518cam a2200745zi 4500",
+  "type": "compare",
+  "expectedPoints": 0.0,
+
+    "featuresA": [{
     "fields": [
-      {
-        "tag": "001",
-        "value": "000019643"
-      },
-      {
-        "tag": "008",
-        "value": "831017s1983    fi ||||||||||||||||bfin||"
-      },
-      {
-        "tag": "041",
-        "ind1": "0",
-        "ind2": " ",
-        "subfields": [
-          {
-            "code": "a",
-            "value": "eng"
-          },
-          {
-            "code": "a",
-            "value": "swe"
-          },
-          {
-            "code": "d",
-            "value": "fin"
-          }
-        ]
-      }
+      {"tag": "041", "ind1": "1", "ind2": " ", "subfields": [
+        {"code": "a", "value": "eng"},
+        {"code": "h", "value": "fin"}
+      ]}
     ]
-  }
+  }, "A"],
+  "featuresB": [{
+    "fields": [
+      {"tag": "041", "ind1": "0", "ind2": " ", "subfields": [
+        {"code": "a", "value": "eng"}
+      ]}
+
+    ]
+  }, "B"],
+  "skip": false,
+  "only": false
 }

--- a/test-fixtures/match-detection/features/bib/language/17/metadata.json
+++ b/test-fixtures/match-detection/features/bib/language/17/metadata.json
@@ -1,8 +1,16 @@
 {
-  "description": "Comparison should return points for (multiple) matching languages",
+  "description": "Comparison should return points for (multiple) matching languages in f041s",
   "feature": "language",
   "type": "compare",
   "expectedPoints": 0.1,
-  "featuresA": ["eng","fin"],
-  "featuresB": ["eng","fin"]
+  "featuresA": [{
+    "fields": [
+      {"tag": "041", "ind1": " ", "ind2": " ", "subfields": [{"code": "a", "value": "eng"}, {"code": "a", "value": "fin"}]}
+    ]
+  }, "A"],
+  "featuresB": [{
+    "fields": [
+      {"tag": "041", "ind1": " ", "ind2": " ", "subfields": [{"code": "a", "value": "eng"}, {"code": "a", "value": "fin"}]}
+    ]
+  }, "B"]
 }

--- a/test-fixtures/match-detection/features/bib/language/18/metadata.json
+++ b/test-fixtures/match-detection/features/bib/language/18/metadata.json
@@ -3,8 +3,16 @@
   "feature": "language",
   "type": "compare",
   "expectedPoints": 0.05,
-  "featuresA": ["eng", "swe"],
-  "featuresB": ["eng","fin"],
+  "featuresA": [{
+    "fields": [
+      {"tag": "041", "ind1": " ", "ind2": " ", "subfields": [{"code": "a", "value": "eng"}, {"code": "a", "value": "swe"}]}
+    ]
+  }, "A"],
+  "featuresB": [{
+    "fields": [
+      {"tag": "041", "ind1": " ", "ind2": " ", "subfields": [{"code": "a", "value": "eng"}, {"code": "a", "value": "fin"}]}
+    ]
+  }, "B"],
   "skip": false,
   "only": false
 }

--- a/test-fixtures/match-detection/features/bib/language/19/metadata.json
+++ b/test-fixtures/match-detection/features/bib/language/19/metadata.json
@@ -1,32 +1,32 @@
 {
-  "description": "Should not extract non-valid language from 041 (||| in 008)",
+  "description": "Compare differently structured 041 fields with the same data. Should return points.",
   "feature": "language",
-  "type": "extract",
-  "expectedFeatures": [],
-  "inputRecord": {
-    "leader": "02518cam a2200745zi 4500",
+  "type": "compare",
+  "expectedPoints": 0.1,
+
+    "featuresA": [{
     "fields": [
-      {
-        "tag": "001",
-        "value": "000019643"
-      },
-      {
-        "tag": "008",
-        "value": "831017s1983    fi ||||||||||||||||b|||||"
-      },
-      {
-        "tag": "041",
-        "ind1": "0",
-        "ind2": " ",
-        "subfields": [
-          {
-            "code": "a",
-            "value": "!x!"
-          }
-        ]
-      }
+      {"tag": "041", "ind1": " ", "ind2": " ", "subfields": [
+        {"code": "a", "value": "eng"}
+      ]},
+      {"tag": "041", "ind1": " ", "ind2": " ", "subfields": [
+        {"code": "a", "value": "swe"}
+      ]},
+      {"tag": "041", "ind1": " ", "ind2": " ", "subfields": [
+        {"code": "a", "value": "fin"}
+      ]}
     ]
-  },
+  }, "A"],
+  "featuresB": [{
+    "fields": [
+      {"tag": "041", "ind1": " ", "ind2": " ", "subfields": [
+        {"code": "a", "value": "eng"},
+        {"code": "a", "value": "fin"},
+        {"code": "a", "value": "swe"}
+      ]}
+
+    ]
+  }, "B"],
   "skip": false,
   "only": false
 }

--- a/test-fixtures/match-detection/features/bib/language/20/metadata.json
+++ b/test-fixtures/match-detection/features/bib/language/20/metadata.json
@@ -1,32 +1,24 @@
 {
-  "description": "Should not extract non valid language from 041 (||| in 008)",
+  "description": "Unexpected language code is ignored as typo/whatever, thus no value -> no penalty (giving a penalty might not be wrong though)",
   "feature": "language",
-  "type": "extract",
-  "expectedFeatures": [],
-  "inputRecord": {
-    "leader": "02518cam a2200745zi 4500",
+  "type": "compare",
+  "expectedPoints": 0.0,
+
+    "featuresA": [{
     "fields": [
-      {
-        "tag": "001",
-        "value": "000019643"
-      },
-      {
-        "tag": "008",
-        "value": "831017s1983    fi ||||||||||||||||b|||||"
-      },
-      {
-        "tag": "041",
-        "ind1": "0",
-        "ind2": " ",
-        "subfields": [
-          {
-            "code": "a",
-            "value": "finnish"
-          }
-        ]
-      }
+      {"tag": "041", "ind1": " ", "ind2": " ", "subfields": [
+        {"code": "a", "value": "illegal"}
+      ]}
     ]
-  },
+  }, "A"],
+  "featuresB": [{
+    "fields": [
+      {"tag": "041", "ind1": " ", "ind2": " ", "subfields": [
+        {"code": "a", "value": "eng"}
+      ]}
+
+    ]
+  }, "B"],
   "skip": false,
   "only": false
 }

--- a/test-fixtures/match-detection/features/bib/language/21/metadata.json
+++ b/test-fixtures/match-detection/features/bib/language/21/metadata.json
@@ -1,32 +1,24 @@
 {
-  "description": "Should not extract non valid language from 041 (||| in 008)",
+  "description": "'mul' vs a single language code should result in penalty",
   "feature": "language",
-  "type": "extract",
-  "expectedFeatures": [],
-  "inputRecord": {
-    "leader": "02518cam a2200745zi 4500",
+  "type": "compare",
+  "expectedPoints": -1.0,
+
+    "featuresA": [{
     "fields": [
-      {
-        "tag": "001",
-        "value": "000019643"
-      },
-      {
-        "tag": "008",
-        "value": "831017s1983    fi ||||||||||||||||b|||||"
-      },
-      {
-        "tag": "041",
-        "ind1": "0",
-        "ind2": " ",
-        "subfields": [
-          {
-            "code": "a",
-            "value": "mul"
-          }
-        ]
-      }
+      {"tag": "041", "ind1": " ", "ind2": " ", "subfields": [
+        {"code": "a", "value": "mul"}
+      ]}
     ]
-  },
+  }, "A"],
+  "featuresB": [{
+    "fields": [
+      {"tag": "041", "ind1": " ", "ind2": " ", "subfields": [
+        {"code": "a", "value": "eng"}
+      ]}
+
+    ]
+  }, "B"],
   "skip": false,
   "only": false
 }

--- a/test-fixtures/match-detection/features/bib/language/22/metadata.json
+++ b/test-fixtures/match-detection/features/bib/language/22/metadata.json
@@ -3,8 +3,16 @@
   "feature": "language",
   "type": "compare",
   "expectedPoints": 0.08,
-  "featuresA": ["eng"],
-  "featuresB": ["eng","fin"],
+  "featuresA": [{
+    "fields": [
+      {"tag": "041", "ind1": " ", "ind2": " ", "subfields": [{"code": "a", "value": "rum"}]}
+    ]
+  }, "A"],
+  "featuresB": [{
+    "fields": [
+      {"tag": "041", "ind1": " ", "ind2": " ", "subfields": [{"code": "a", "value": "rum"}, {"code": "a", "value": "fin"}]}
+    ]
+  }, "B"],
   "skip": false,
   "only": false
 }

--- a/test-fixtures/match-detection/features/bib/language/23/metadata.json
+++ b/test-fixtures/match-detection/features/bib/language/23/metadata.json
@@ -1,10 +1,31 @@
 {
-  "description": "Comparison should return minimal amount of points for partially matching languages (1 match, 2 mismatches, 5 missing)",
+  "description": "'mul' vs multiple language codes should not result in penalty",
   "feature": "language",
   "type": "compare",
-  "expectedPoints": -0.10,
-  "featuresA": ["eng","dan","sme"],
-  "featuresB": ["eng","fin","swe","nor","lat","heb","ara","spa"],
+  "expectedPoints": 0.0,
+
+    "featuresA": [{
+    "fields": [
+      {"tag": "041", "ind1": " ", "ind2": " ", "subfields": [
+        {"code": "a", "value": "mul"}
+      ]}
+    ]
+  }, "A"],
+  "featuresB": [{
+    "fields": [
+      {"tag": "041", "ind1": " ", "ind2": " ", "subfields": [
+        {"code": "a", "value": "eng"},
+        {"code": "a", "value": "fin"},
+        {"code": "a", "value": "swe"},
+        {"code": "a", "value": "nor"},
+        {"code": "a", "value": "lat"},
+        {"code": "a", "value": "heb"},
+        {"code": "a", "value": "ara"},
+        {"code": "a", "value": "spa"}
+      ]}
+
+    ]
+  }, "B"],
   "skip": false,
   "only": false
 }

--- a/test-fixtures/match-detection/features/bib/language/24/metadata.json
+++ b/test-fixtures/match-detection/features/bib/language/24/metadata.json
@@ -1,0 +1,14 @@
+{
+  "description": "Comparison should not return points for missing language in both. (No fields at all; tests robustness)",
+  "feature": "language",
+  "type": "compare",
+  "expectedPoints": 0,
+  "featuresA": [{
+    "fields": [
+    ]
+  }, "A"],
+  "featuresB": [{
+    "fields": [
+    ]
+  }, "B"]
+}

--- a/test-fixtures/match-detection/features/bib/other-standard-identifier/03/metadata.json
+++ b/test-fixtures/match-detection/features/bib/other-standard-identifier/03/metadata.json
@@ -1,16 +1,12 @@
 {
-  "description": "Crappy code pair does not look like isbn13 (ends in X). Thus the pair contains nothing to be compared...",
+  "description": "Comparison should return points for matching invalid standard identifiers",
   "feature": "otherStandardIdentifier",
   "type": "compare",
-  "expectedPoints": 0.0,
+  "expectedPoints": 0.2,
   "featuresA": [
-    { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [
-      { "code": "z", "value": "978044990620X" }
-    ]}
+    { "code": "z", "value": "978044990620X" }
   ],
   "featuresB": [
-    { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [
-      { "code": "z", "value": "978044990620X" }
-    ]}
+    { "code": "z", "value": "978044990620X" }
   ]
 }

--- a/test-fixtures/match-detection/features/bib/other-standard-identifier/03/metadata.json
+++ b/test-fixtures/match-detection/features/bib/other-standard-identifier/03/metadata.json
@@ -1,12 +1,16 @@
 {
-  "description": "Comparison should return points for matching invalid standard identifiers",
+  "description": "Crappy code pair does not look like isbn13 (ends in X). Thus the pair contains nothing to be compared...",
   "feature": "otherStandardIdentifier",
   "type": "compare",
-  "expectedPoints": 0.2,
+  "expectedPoints": 0.0,
   "featuresA": [
-    { "code": "z", "value": "978044990620X" }
+    { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "z", "value": "978044990620X" }
+    ]}
   ],
   "featuresB": [
-    { "code": "z", "value": "978044990620X" }
+    { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "z", "value": "978044990620X" }
+    ]}
   ]
 }

--- a/test-fixtures/match-detection/features/bib/title-version-original/04/metadata.json
+++ b/test-fixtures/match-detection/features/bib/title-version-original/04/metadata.json
@@ -1,5 +1,5 @@
 {
-  "description": "Comparison should return points for matching titles (Different values, distance under treshold)",
+  "description": "Comparison should return points for matching titles (Different values, distance under threshold)",
   "feature": "titleVersionOriginal",
   "type": "compare",
   "expectedPoints": 0.3,

--- a/test-fixtures/match-detection/features/bib/title/c-02/metadata.json
+++ b/test-fixtures/match-detection/features/bib/title/c-02/metadata.json
@@ -1,5 +1,5 @@
 {
-  "description": "Comparison should return plus points for matching titles (Different values, distance under treshold)",
+  "description": "Comparison should return plus points for matching titles (Different values, distance under threshold)",
   "feature": "title",
   "type": "compare",
   "expectedPoints": 0.3,

--- a/test-fixtures/match-detection/index/03/metadata.json
+++ b/test-fixtures/match-detection/index/03/metadata.json
@@ -1,5 +1,5 @@
 {
-  "description": "Should not detect a match (Minimum treshold not reached)",
+  "description": "Should not detect a match (Minimum threshold not reached)",
   "options": {
     "strategy": {
       "type": "bib",


### PR DESCRIPTION
- MELKEHITYS-3362: handle sami languages properly (add 'smi' if needed), tune scoring
- MELKEHITYS-3367-ish: improved language code handling for und, zxx and mul
- Identifiers changes
-- non-matching identifiers do not cause a penalty if there's a match elsewhere,
-- use comp 773$x and $y values
-- changes in non-valid isbn handlings
- bibliographic level (LDR/07): 'a' vs 'b' does not cause a penalty
- host-component: change comp definition from 773 to 773/973

-TODO(?) title-version-original uses 245$a$b for title. Should we include $n and $p?