### PR TITLE
Yso

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -691,18 +691,18 @@
 			}
 		},
 		"node_modules/@mongodb-js/saslprep": {
-			"version": "1.4.8",
-			"resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.8.tgz",
-			"integrity": "sha512-kpjr2jy2w71w0oqAMI8oibBmiF9lXxWkEQs5gMkW4hVE48bsqINGLxnCSYW62ck/NHXJQpQEfA9WlJ1sY0eqBg==",
+			"version": "1.4.9",
+			"resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.9.tgz",
+			"integrity": "sha512-RXSxsokhAF/4nWys8An8npsqOI33Ex1Hlzqjw2pZOO+GKtMAR2noGnUdsFiGwsaO/xXI+56mtjTmDA3JXJsvmA==",
 			"license": "MIT",
 			"dependencies": {
 				"sparse-bitfield": "^3.0.3"
 			}
 		},
 		"node_modules/@mswjs/interceptors": {
-			"version": "0.41.4",
-			"resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.4.tgz",
-			"integrity": "sha512-3B9EinUkrdOUGYzHRzRWSXunQ4YFGboJnyLNRwEJWEde+j8fNhPUHvrN1E3g1DU/iS/s8JQrMNVe+S7AHHVs0w==",
+			"version": "0.41.6",
+			"resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.6.tgz",
+			"integrity": "sha512-qmDvJIjcNsZ6tXWy2G9yuCgMPTTn35GMA3dPpSLm7QJVpbQzYdw0ALy1bKoivXnEM3U93/OrK+/M719b+fg84Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1130,9 +1130,9 @@
 			}
 		},
 		"node_modules/ajv": {
-			"version": "6.14.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-			"integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+			"integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2376,9 +2376,9 @@
 			}
 		},
 		"node_modules/nodemailer": {
-			"version": "8.0.5",
-			"resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.5.tgz",
-			"integrity": "sha512-0PF8Yb1yZuQfQbq+5/pZJrtF6WQcjTd5/S4JOHs9PGFxuTqoB/icwuB44pOdURHJbRKX1PPoJZtY7R4VUoCC8w==",
+			"version": "8.0.7",
+			"resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.7.tgz",
+			"integrity": "sha512-pkjE4mkBzQjdJT4/UmlKl3pX0rC9fZmjh7c6C9o7lv66Ac6w9WCnzPzhbPNxwZAzlF4mdq4CSWB5+FbK6FWCow==",
 			"license": "MIT-0",
 			"engines": {
 				"node": ">=6.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
 				"@natlibfi/melinda-commons": "^14.0.2",
 				"@natlibfi/sru-client": "^7.0.1",
 				"debug": "^4.4.3",
-				"isbn3": "^2.0.6",
+				"isbn3": "^2.0.7",
 				"moment": "^2.30.1",
 				"natural": "^8.1.1",
 				"uuid": "^14.0.0",
@@ -30,7 +30,7 @@
 				"@natlibfi/fixura": "^4.0.1",
 				"cross-env": "^10.1.0",
 				"esbuild": "^0.28.0",
-				"eslint": "^10.2.1"
+				"eslint": "^10.3.0"
 			},
 			"engines": {
 				"node": ">=22"
@@ -691,18 +691,18 @@
 			}
 		},
 		"node_modules/@mongodb-js/saslprep": {
-			"version": "1.4.9",
-			"resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.9.tgz",
-			"integrity": "sha512-RXSxsokhAF/4nWys8An8npsqOI33Ex1Hlzqjw2pZOO+GKtMAR2noGnUdsFiGwsaO/xXI+56mtjTmDA3JXJsvmA==",
+			"version": "1.4.11",
+			"resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.4.11.tgz",
+			"integrity": "sha512-o9rAHc0IpIjuPSxRutWpE1F62x7n+4mVS4rCNHkzhIUMQcc18bb6xEq5wd2NdN0WjepIyXIppRshYI2kQDOZVA==",
 			"license": "MIT",
 			"dependencies": {
 				"sparse-bitfield": "^3.0.3"
 			}
 		},
 		"node_modules/@mswjs/interceptors": {
-			"version": "0.41.6",
-			"resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.6.tgz",
-			"integrity": "sha512-qmDvJIjcNsZ6tXWy2G9yuCgMPTTn35GMA3dPpSLm7QJVpbQzYdw0ALy1bKoivXnEM3U93/OrK+/M719b+fg84Q==",
+			"version": "0.41.8",
+			"resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.8.tgz",
+			"integrity": "sha512-pRLMNKTSGRoLq+KnEB/7OY5vijw1XmcheAAOiv6pj7W1FG32kAGqj1C/RK/cqxRGr1Fh+zBi8sDur8kj3EQv6A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1597,9 +1597,9 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "10.2.1",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-10.2.1.tgz",
-			"integrity": "sha512-wiyGaKsDgqXvF40P8mDwiUp/KQjE1FdrIEJsM8PZ3XCiniTMXS3OHWWUe5FI5agoCnr8x4xPrTDZuxsBlNHl+Q==",
+			"version": "10.3.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-10.3.0.tgz",
+			"integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2017,9 +2017,9 @@
 			}
 		},
 		"node_modules/isbn3": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/isbn3/-/isbn3-2.0.6.tgz",
-			"integrity": "sha512-RrJy7jsXki4+QK/D2/ZH2lKi3oOr+xcgIMf2VXrDZ3DduE4awmu2XJ0Z/zu5j0L6XIGWbJUhe0UYD2BlRgwLrA==",
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/isbn3/-/isbn3-2.0.7.tgz",
+			"integrity": "sha512-FYsoxXRHwj7GGr9xVp4UigwMWJFMzCYbDxWAb17/BG7d3Ml7TnzWxIyZhNtLvD1NVrUrzKF/MT9xogVFfd+jAQ==",
 			"license": "MIT",
 			"bin": {
 				"isbn": "bin/isbn",
@@ -2202,13 +2202,13 @@
 			}
 		},
 		"node_modules/mongodb": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-7.1.1.tgz",
-			"integrity": "sha512-067DXiMjcpYQl6bGjWQoTUEE9UoRViTtKFcoqX7z08I+iDZv/emH1g8XEFiO3qiDfXAheT5ozl1VffDTKhIW/w==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-7.2.0.tgz",
+			"integrity": "sha512-F/2+BMZtLVhY30ioZp0dAmZ+IRZMBqI+nrv6t5+9/1AIwCa8sMRC3jBf81lpxMhnZgqq8CoUD503Z1oZWq1/sw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@mongodb-js/saslprep": "^1.3.0",
-				"bson": "^7.1.1",
+				"bson": "^7.2.0",
 				"mongodb-connection-string-url": "^7.0.0"
 			},
 			"engines": {
@@ -2261,13 +2261,13 @@
 			}
 		},
 		"node_modules/mongoose": {
-			"version": "9.5.0",
-			"resolved": "https://registry.npmjs.org/mongoose/-/mongoose-9.5.0.tgz",
-			"integrity": "sha512-B4blGFkFL1s0G24URuMvx0qTlx+gRVLmfO7WcSz8NcmW/XHEJ3G69capdyW1iRsGKiycp1tkwKHnxHbnwjwmPw==",
+			"version": "9.6.1",
+			"resolved": "https://registry.npmjs.org/mongoose/-/mongoose-9.6.1.tgz",
+			"integrity": "sha512-3T8/b0plM3ZJPW3WjlzVMIGJEYYTjgDPQ05Qzru3xu3/wOPSFKWYxdwUF2dl8h3NG5dVkzIuOkZdLacnlLf/sA==",
 			"license": "MIT",
 			"dependencies": {
 				"kareem": "3.3.0",
-				"mongodb": "~7.1",
+				"mongodb": "~7.2",
 				"mpath": "0.9.0",
 				"mquery": "6.0.0",
 				"ms": "2.1.3",
@@ -2348,9 +2348,9 @@
 			"license": "MIT"
 		},
 		"node_modules/nock": {
-			"version": "14.0.13",
-			"resolved": "https://registry.npmjs.org/nock/-/nock-14.0.13.tgz",
-			"integrity": "sha512-SCPsQmGVNY8h1rfS3aU0MzOGYY+wKIFukHEsoSIwPRCYocZkya7MFIlWIEYPWQZj+Gaksg6EyUaY255ZDqpQuA==",
+			"version": "14.0.14",
+			"resolved": "https://registry.npmjs.org/nock/-/nock-14.0.14.tgz",
+			"integrity": "sha512-PKk7tex0O3RRXUZC5XDKJ9yM3rYRPS13myduT85VIIYDBnib42Fpxoe6KxRSzqB4iL2NDxkcJ2yiskZ18hGLEQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2347,19 +2347,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/natural/node_modules/uuid": {
-			"version": "13.0.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-			"integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
-			"funding": [
-				"https://github.com/sponsors/broofa",
-				"https://github.com/sponsors/ctavan"
-			],
-			"license": "MIT",
-			"bin": {
-				"uuid": "dist-node/bin/uuid"
-			}
-		},
 		"node_modules/nock": {
 			"version": "14.0.13",
 			"resolved": "https://registry.npmjs.org/nock/-/nock-14.0.13.tgz",

--- a/package.json
+++ b/package.json
@@ -58,5 +58,8 @@
 		"cross-env": "^10.1.0",
 		"esbuild": "^0.28.0",
 		"eslint": "^10.2.1"
+	},
+	"overrides": {
+		"uuid": "^14.0.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
 		"@natlibfi/melinda-commons": "^14.0.2",
 		"@natlibfi/sru-client": "^7.0.1",
 		"debug": "^4.4.3",
-		"isbn3": "^2.0.6",
+		"isbn3": "^2.0.7",
 		"moment": "^2.30.1",
 		"natural": "^8.1.1",
 		"uuid": "^14.0.0",
@@ -57,7 +57,7 @@
 		"@natlibfi/fixura": "^4.0.1",
 		"cross-env": "^10.1.0",
 		"esbuild": "^0.28.0",
-		"eslint": "^10.2.1"
+		"eslint": "^10.3.0"
 	},
 	"overrides": {
 		"uuid": "^14.0.0"

--- a/src/candidate-search/index.js
+++ b/src/candidate-search/index.js
@@ -73,7 +73,6 @@ export default async ({record, searchSpec, url, maxCandidates, maxRecordsPerRequ
 
   return {search};
 
-  // eslint-disable-next-line max-statements
   async function search({queryOffset = 0, resultSetOffset = 1, totalRecords = 0, searchCounter = 0, queryCandidateCounter = 0, queryCounter = 0, maxedQueries = []}) {
     const query = chosenQueryList[queryOffset];
     debug(`Running query ${JSON.stringify(query)} (${queryOffset})`);
@@ -124,7 +123,6 @@ export default async ({record, searchSpec, url, maxCandidates, maxRecordsPerRequ
 
 export function retrieveRecords(client, query, resultSetOffset) {
   const debug = createDebugLogger('@natlibfi/melinda-record-matching:candidate-search:retrieveRecords');
-  // eslint-disable-next-line no-unused-vars
   const debugData = debug.extend('data');
 
   return new Promise((resolve, reject) => {

--- a/src/candidate-search/index.test.js
+++ b/src/candidate-search/index.test.js
@@ -19,7 +19,6 @@ describe('candidate-search', () => {
     }
   });
 
-  // eslint-disable-next-line max-statements
   async function callback({getFixture, factoryOptions, searchOptions, expectedFactoryError = false, expectedSearchError = false, enabled = true}) {
     const url = 'http://foo.bar';
 

--- a/src/candidate-search/index.test.js
+++ b/src/candidate-search/index.test.js
@@ -19,12 +19,8 @@ describe('candidate-search', () => {
     }
   });
 
-  async function callback({getFixture, factoryOptions, searchOptions, expectedFactoryError = false, expectedSearchError = false, enabled = true}) {
+  async function callback({getFixture, factoryOptions, searchOptions, expectedFactoryError = false, expectedSearchError = false}) {
     const url = 'http://foo.bar';
-
-    if (!enabled) {
-      return;
-    }
 
     if (expectedFactoryError) {
       debug(`We're expecting an error`);

--- a/src/candidate-search/query-list/auth.js
+++ b/src/candidate-search/query-list/auth.js
@@ -1,0 +1,24 @@
+import createDebugLogger from 'debug';
+import {toQueries} from '../candidate-search-utils.js';
+
+const debug = createDebugLogger('@natlibfi/melinda-record-matching:candidate-search:query-list:auth');
+
+export function authStandardIdentifiers(record) {
+    const a = recordGetAuthIdentifiers(record);
+
+    if (a.length === 0) {
+        debug(`No identifiers found, no queries created.`);
+        return [];
+    }
+    return toQueries(a, 'melinda.urx');
+}
+
+export function recordGetAuthIdentifiers(record) {
+    const f024s = record.get(/024/u);
+    if (f024s.length > 0) {
+        debug(`${f024s.length} ids found`);
+        const values = f024s.map(f => f.subfields).flat().filter(sf => sf.code === 'a').map(sf => sf.value);
+        return values;
+    }
+    return [];
+}

--- a/src/candidate-search/query-list/auth.js
+++ b/src/candidate-search/query-list/auth.js
@@ -14,9 +14,11 @@ export function authStandardIdentifiers(record) {
 }
 
 export function recordGetAuthIdentifiers(record) {
-    const f024s = record.get(/024/u);
+    // NB! Should we check and/or return 024$2? Probably not needed in our domain...
+    const f024s = record.get(/024/u); // f024 is repeatable
     if (f024s.length > 0) {
         debug(`${f024s.length} ids found`);
+        // NB! f024$a is a non-repeatable subfield, but we are not checking that here
         const values = f024s.map(f => f.subfields).flat().filter(sf => sf.code === 'a').map(sf => sf.value);
         return values;
     }

--- a/src/candidate-search/query-list/auth.js
+++ b/src/candidate-search/query-list/auth.js
@@ -3,8 +3,8 @@ import {toQueries} from '../candidate-search-utils.js';
 
 const debug = createDebugLogger('@natlibfi/melinda-record-matching:candidate-search:query-list:auth');
 
-export function authStandardIdentifiers(record) {
-    const a = recordGetAuthIdentifiers(record);
+export function authURX(record) {
+    const a = recordGetAuthURX(record);
 
     if (a.length === 0) {
         debug(`No identifiers found, no queries created.`);
@@ -13,11 +13,10 @@ export function authStandardIdentifiers(record) {
     return toQueries(a, 'melinda.urx');
 }
 
-export function recordGetAuthIdentifiers(record) {
-    // NB! Should we check and/or return 024$2? Probably not needed in our domain...
-    const f024s = record.get(/024/u); // f024 is repeatable
+export function recordGetAuthURX(record) {
+    const f024s = record.get(/024/u).filter(f => f.subfields.some(sf => sf.code === '2' && ['uri', 'urn'].includes(sf.value))); // f024 is repeatable
     if (f024s.length > 0) {
-        debug(`${f024s.length} ids found`);
+        debug(`${f024s.length} id(s) found`);
         // NB! f024$a is a non-repeatable subfield, but we are not checking that here
         const values = f024s.map(f => f.subfields).flat().filter(sf => sf.code === 'a').map(sf => sf.value);
         return values;

--- a/src/candidate-search/query-list/auth.test.js
+++ b/src/candidate-search/query-list/auth.test.js
@@ -1,0 +1,38 @@
+import assert from 'node:assert';
+import {describe} from 'node:test';
+import createDebugLogger from 'debug';
+import generateTests from '@natlibfi/fixugen';
+import {READERS} from '@natlibfi/fixura';
+import {MarcRecord} from '@natlibfi/marc-record';
+import * as generators from './auth.js';
+
+const debug = createDebugLogger('@natlibfi/melinda-record-matching:candidate-search:query-list:auth-test');
+const debugData = debug.extend('data');
+
+describe('candidate-search/query-list/auth/', () => {
+  generateTests({
+    path: [import.meta.dirname, '..', '..', '..', 'test-fixtures', 'candidate-search', 'query-list', 'auth'],
+    useMetadataFile: true,
+    fixura: {
+      reader: READERS.JSON
+    },
+    callback: ({type, inputRecord, expectedQuery, expectedQueryListType, enabled = true}) => {
+      const generate = generators[type];
+      const record = new MarcRecord(inputRecord, {subfieldValues: false});
+
+      if (!enabled) {
+        return;
+      }
+
+      const result = generate(record);
+      debugData(`Result: ${JSON.stringify(result)}`);
+
+      if (result.queryListType) {
+        assert.deepStrictEqual(result.queryList, expectedQuery);
+        assert.equal(result.queryListType, expectedQueryListType);
+        return;
+      }
+      assert.deepStrictEqual(result, expectedQuery);
+    }
+  });
+});

--- a/src/candidate-search/query-list/auth.test.js
+++ b/src/candidate-search/query-list/auth.test.js
@@ -16,13 +16,9 @@ describe('candidate-search/query-list/auth/', () => {
     fixura: {
       reader: READERS.JSON
     },
-    callback: ({type, inputRecord, expectedQuery, expectedQueryListType, enabled = true}) => {
+    callback: ({type, inputRecord, expectedQuery, expectedQueryListType}) => {
       const generate = generators[type];
       const record = new MarcRecord(inputRecord, {subfieldValues: false});
-
-      if (!enabled) {
-        return;
-      }
 
       const result = generate(record);
       debugData(`Result: ${JSON.stringify(result)}`);

--- a/src/candidate-search/query-list/bib.js
+++ b/src/candidate-search/query-list/bib.js
@@ -332,8 +332,7 @@ export function bibAuthors(record) {
 
   function getAuthor(record) {
     //debugData(record);
-    // eslint-disable-next-line prefer-named-capture-group
-    const [field] = record.get(/^(100)|(110)|(111)|(700)|(710)|(711)$/u);
+    const [field] = record.get(/^(?:100|110|111|700|710|711)$/u);
     //debugData(field);
 
     if (field) {

--- a/src/candidate-search/query-list/bib.test.js
+++ b/src/candidate-search/query-list/bib.test.js
@@ -16,13 +16,9 @@ describe('candidate-search/query-list/bib/', () => {
     fixura: {
       reader: READERS.JSON
     },
-    callback: ({type, inputRecord, expectedQuery, expectedQueryListType, enabled = true}) => {
+    callback: ({type, inputRecord, expectedQuery, expectedQueryListType}) => {
       const generate = generators[type];
       const record = new MarcRecord(inputRecord, {subfieldValues: false});
-
-      if (!enabled) {
-        return;
-      }
 
       const result = generate(record);
       debugData(`Result: ${JSON.stringify(result)}`);

--- a/src/candidate-search/query-list/component.js
+++ b/src/candidate-search/query-list/component.js
@@ -44,7 +44,7 @@ export function parse773g(field) {
     if (value.match(/^[0-9]+(?:-[0-9]+)?(?:, [0-9]+(?:-[0-9]+)?)*$/u)) {
       return value;
     }
-    const numberPartOnly = value.replace(/^.*(?:p\.|raidat|raita|s\.|Seite|sivut?|pages?) /ui, '');
+    const numberPartOnly = value.replace(/^.*(?:p\.|raidat|raita|\bs\.|Seite|sivut?|pages?) /ui, '');
     if (numberPartOnly !== value) {
       return gToPages(numberPartOnly);
     }

--- a/src/candidate-search/query-list/component.js
+++ b/src/candidate-search/query-list/component.js
@@ -4,10 +4,10 @@ import {toQueries} from '../candidate-search-utils.js';
 import {getSubfieldValues, stringAfter, stringBefore, testStringOrNumber, toMelindaIds} from '../../matching-utils.js';
 import {fieldToString, uniqArray} from '@natlibfi/marc-record-validators-melinda/dist/utils.js';
 
-const setTimeoutPromise = promisify(setTimeout); // eslint-disable-line
+const setTimeoutPromise = promisify(setTimeout);
 
 const debug = createDebugLogger('@natlibfi/melinda-record-matching:candidate-search:query:component');
-const debugData = debug.extend('data'); // eslint-disable-line
+const debugData = debug.extend('data');
 
 
 
@@ -116,7 +116,7 @@ export function hostIdMelinda(record) { // old function with replaced code
 
 export async function hostIdOtherSource(record, client) {
   const debug = createDebugLogger('@natlibfi/melinda-record-matching:candidate-search:query:hostIdOtherSource');
-  const debugData = debug.extend('data'); // eslint-disable-line
+  const debugData = debug.extend('data');
   debug(`Creating query for the Other source Id host`);
 
   const ids = getHostIds(record);

--- a/src/candidate-search/query-list/index.js
+++ b/src/candidate-search/query-list/index.js
@@ -1,5 +1,6 @@
 import * as bib from './bib.js';
 import * as component from './component.js';
+import * as auth from './auth.js';
 import createDebugLogger from 'debug';
 
 const debug = createDebugLogger('@natlibfi/melinda-record-matching:candidate-search:index');
@@ -21,11 +22,16 @@ export const searchTypes = {
     hostIdMelinda: 'hostIdMelinda', // 773 $w (FI-MELINDA)
     hostIdOtherSource: 'hostIdOtherSource', // 773 $w !(FI-MELINDA)
     hostIsbn: 'hostIsbn' // 773 $z
+  },
+  auth: {
+    //catalogingRules: 'authCatalogingRules', // 008/10 and 040$f
+    //term: 'authTermComparison' // 1XX
+    authStandardIdentifiers: 'authStandardIdentifiers' // 024$a
   }
 };
 
 export default async (record, searchSpec, client) => {
-  const extractors = {...bib, ...component};
+  const extractors = {...auth, ...bib, ...component};
   debugData(`extractors: ${JSON.stringify(extractors)}`);
   debugData(`searchSpec: ${JSON.stringify(searchSpec)}`);
 

--- a/src/candidate-search/query-list/index.js
+++ b/src/candidate-search/query-list/index.js
@@ -26,7 +26,7 @@ export const searchTypes = {
   auth: {
     //catalogingRules: 'authCatalogingRules', // 008/10 and 040$f
     //term: 'authTermComparison' // 1XX
-    authStandardIdentifiers: 'authStandardIdentifiers' // 024$a
+    authURX: 'authURX' // 024$a
   }
 };
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -42,7 +42,7 @@ async function cli() {
         throw new Error('Setup sru url');
       }
 
-      if (!['IDS', 'STANDARD_IDS', 'COMPONENT', 'CONTENT', 'CONTENTALT'].includes(args.searchType)) {
+      if (!['IDS', 'STANDARD_IDS', 'COMPONENT', 'CONTENT', 'CONTENTALT', 'YSO'].includes(args.searchType)) {
         throw new Error('Invalid search type');
       }
 
@@ -136,6 +136,12 @@ async function cli() {
       ];
     }
 
+    if (['YSO']) {
+      return [
+        matchDetection.features.auth.yso()
+      ];
+    }
+
     throw new Error('Unsupported match validation package');
   }
 
@@ -173,6 +179,12 @@ async function cli() {
         // titleAuthorYearAlternates searches for matchCandidates
         // with alternate queries, starting from more tight searches
         candidateSearch.searchTypes.bib.titleAuthorYearAlternates
+      ];
+    }
+
+    if (searchType === 'YSO') {
+      return [
+        candidateSearch.searchTypes.auth.authStandardIdentifiers
       ];
     }
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -184,7 +184,7 @@ async function cli() {
 
     if (searchType === 'YSO') {
       return [
-        candidateSearch.searchTypes.auth.authStandardIdentifiers
+        candidateSearch.searchTypes.auth.authURX
       ];
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -161,7 +161,6 @@ export default ({detection: detectionOptions, search: searchOptions, maxMatches 
         return;
       }
 
-      // eslint-disable-next-line max-statements
       function getMatchState(state, stopReason, matchErrorCount) {
         debugData(`${JSON.stringify(state)}`);
         debug(`We had ${matchErrorCount} retrieved candidates that errored in matchDetection.`);

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -19,7 +19,6 @@ describe('INDEX', () => {
     }
   });
 
-  // eslint-disable-next-line max-statements
   async function callback({getFixture, options, expectedMatchStatus, expectedStopReason, expectedFailures, expectedCandidateCount}) {
 
     const record = new MarcRecord(getFixture('inputRecord.json'), {subfieldValues: false});

--- a/src/match-detection/features/auth/index.js
+++ b/src/match-detection/features/auth/index.js
@@ -1,0 +1,1 @@
+export {default as yso} from './yso.js'

--- a/src/match-detection/features/auth/index.test.js
+++ b/src/match-detection/features/auth/index.test.js
@@ -1,0 +1,52 @@
+
+import assert from 'node:assert';
+import {describe} from 'node:test';
+import createDebugLogger from 'debug';
+import generateTests from '@natlibfi/fixugen';
+import {READERS} from '@natlibfi/fixura';
+import {MarcRecord} from '@natlibfi/marc-record';
+import * as features from './index.js';
+
+
+const debug = createDebugLogger('@natlibfi/melinda-record-matching:match-detection:features/auth:test');
+const debugData = debug.extend('data');
+
+
+describe('match-detection/features/auth/', () => {
+  generateTests({
+    path: [import.meta.dirname, '..', '..', '..', '..', 'test-fixtures', 'match-detection', 'features', 'auth'],
+    useMetadataFile: true,
+    fixura: {
+      reader: READERS.JSON
+    },
+
+    callback: ({enabled = true, feature, options, type, ...expectations}) => {
+
+      if (!enabled) {
+        return;
+      }
+
+      debug(`Testing: ${feature} ${type}`);
+
+      if (type === 'extract') {
+        const {expectedFeatures, inputRecord} = expectations;
+        const record = new MarcRecord(inputRecord, {subfieldValues: false});
+        debugData(`Record: ${record}`);
+        const {extract} = features[feature](options);
+
+        assert.deepStrictEqual(extract({record}), expectedFeatures);
+        return;
+      }
+
+      if (type === 'compare') {
+        const {featuresA, featuresB, expectedPoints} = expectations;
+        const {compare} = features[feature](options);
+
+        assert.equal(Math.round(compare(featuresA, featuresB) *100)/100, expectedPoints);
+        return;
+      }
+
+      throw new Error(`Invalid type ${type}`);
+    }
+  });
+});

--- a/src/match-detection/features/auth/index.test.js
+++ b/src/match-detection/features/auth/index.test.js
@@ -20,12 +20,7 @@ describe('match-detection/features/auth/', () => {
       reader: READERS.JSON
     },
 
-    callback: ({enabled = true, feature, options, type, ...expectations}) => {
-
-      if (!enabled) {
-        return;
-      }
-
+    callback: ({feature, options, type, ...expectations}) => {
       debug(`Testing: ${feature} ${type}`);
 
       if (type === 'extract') {

--- a/src/match-detection/features/auth/yso.js
+++ b/src/match-detection/features/auth/yso.js
@@ -1,0 +1,64 @@
+
+import createDebugLogger from 'debug';
+import {recordGetAuthIdentifiers} from '../../../candidate-search/query-list/auth.js';
+//import {fieldToString} from '@natlibfi/marc-record-validators-melinda';
+
+//import {isComponentRecord} from '@natlibfi/melinda-commons';
+//import {uniqArray} from './issn.js';
+//import {parse773g} from '../../../candidate-search/query-list/component.js';
+
+const debug = createDebugLogger('@natlibfi/melinda-record-matching:match-detection:features:auth:yso');
+const debugData = debug.extend('data');
+
+
+
+function getSubjectHeadingThesaurus(record) {
+  // Quick'n'dirty: we could/should check 008/11 first. Now we just assume it is 'z'
+  const [f040] = record.get('040');
+  if (f040) {
+    // debug(`FOUND 040: ${fieldToString(f040)}`);
+    const sf = f040.subfields?.find(sf => sf.code === 'f');
+    if (sf) {
+      return sf.value;
+    }
+  }
+  return undefined;
+}
+
+export default () => ({
+  name: 'yso',
+  extract: ({record/*, recordExternal*/}) => {
+    const identifiers = recordGetAuthIdentifiers(record);
+
+    const thesaurus = getSubjectHeadingThesaurus(record);
+
+
+    debug(`EXTRACT ${thesaurus}: ${identifiers.join(', ')}`);
+    return {identifiers, thesaurus};
+  },
+
+  compare: (aa, bb) => {
+    const aIdentifiers = aa.identifiers;
+    const aThesaurus = aa.thesaurus;
+    const bIdentifiers = bb.identifiers;
+    const bThesaurus =  bb.thesaurus;
+
+    // Require identical existing thesauri
+    if (!aThesaurus || aThesaurus !== bThesaurus) {
+      return -1.0;
+    }
+    debugData(`Shared thesaurus: ${aThesaurus}`)
+
+    //// Check that identifiers match:
+    // debug(aIdentifiers.join(' -- '));
+    // debug(bIdentifiers.join(' -- '));
+    const sharedIdentifier = aIdentifiers.find(id => bIdentifiers.includes(id));
+    if (!sharedIdentifier) {
+      return -1.0;
+    }
+    debugData(`Shared identifier: ${sharedIdentifier} => MATCH`);
+
+    return 1.0;
+  }
+});
+

--- a/src/match-detection/features/auth/yso.js
+++ b/src/match-detection/features/auth/yso.js
@@ -22,7 +22,7 @@ function getSubjectHeadingThesaurus(record) {
       return sf.value;
     }
   }
-  return undefined;
+  return null;
 }
 
 export default () => ({

--- a/src/match-detection/features/auth/yso.js
+++ b/src/match-detection/features/auth/yso.js
@@ -1,16 +1,9 @@
 
 import createDebugLogger from 'debug';
 import {recordGetAuthIdentifiers} from '../../../candidate-search/query-list/auth.js';
-//import {fieldToString} from '@natlibfi/marc-record-validators-melinda';
-
-//import {isComponentRecord} from '@natlibfi/melinda-commons';
-//import {uniqArray} from './issn.js';
-//import {parse773g} from '../../../candidate-search/query-list/component.js';
 
 const debug = createDebugLogger('@natlibfi/melinda-record-matching:match-detection:features:auth:yso');
 const debugData = debug.extend('data');
-
-
 
 function getSubjectHeadingThesaurus(record) {
   // Quick'n'dirty: we could/should check 008/11 first. Now we just assume it is 'z'
@@ -32,7 +25,6 @@ export default () => ({
 
     const thesaurus = getSubjectHeadingThesaurus(record);
 
-
     debug(`EXTRACT ${thesaurus}: ${identifiers.join(', ')}`);
     return {identifiers, thesaurus};
   },
@@ -49,9 +41,6 @@ export default () => ({
     }
     debugData(`Shared thesaurus: ${aThesaurus}`)
 
-    //// Check that identifiers match:
-    // debug(aIdentifiers.join(' -- '));
-    // debug(bIdentifiers.join(' -- '));
     const sharedIdentifier = aIdentifiers.find(id => bIdentifiers.includes(id));
     if (!sharedIdentifier) {
       return -1.0;

--- a/src/match-detection/features/auth/yso.js
+++ b/src/match-detection/features/auth/yso.js
@@ -1,6 +1,6 @@
 
 import createDebugLogger from 'debug';
-import {recordGetAuthIdentifiers} from '../../../candidate-search/query-list/auth.js';
+import {recordGetAuthURX} from '../../../candidate-search/query-list/auth.js';
 
 const debug = createDebugLogger('@natlibfi/melinda-record-matching:match-detection:features:auth:yso');
 const debugData = debug.extend('data');
@@ -21,7 +21,7 @@ function getSubjectHeadingThesaurus(record) {
 export default () => ({
   name: 'yso',
   extract: ({record/*, recordExternal*/}) => {
-    const identifiers = recordGetAuthIdentifiers(record);
+    const identifiers = recordGetAuthURX(record);
 
     const thesaurus = getSubjectHeadingThesaurus(record);
 

--- a/src/match-detection/features/bib/index.test.js
+++ b/src/match-detection/features/bib/index.test.js
@@ -20,12 +20,7 @@ describe('match-detection/features/bib/', () => {
       reader: READERS.JSON
     },
 
-    callback: ({enabled = true, feature, options, type, ...expectations}) => {
-
-      if (!enabled) {
-        return;
-      }
-
+    callback: ({feature, options, type, ...expectations}) => {
       debug(`Testing: ${feature} ${type}`);
 
       if (type === 'extract') {

--- a/src/match-detection/features/bib/isbn.js
+++ b/src/match-detection/features/bib/isbn.js
@@ -16,7 +16,6 @@ export default () => ({
 
     return record.get('020').filter(f => f.subfields?.some(sf => ['a', 'z'].includes(sf.code) && sf.value));
   },
-  // eslint-disable-next-line max-statements
   compare: (aa, bb) => {
     debugData(`Comparing ISBN sets ${JSON.stringify(aa)} and ${JSON.stringify(bb)}`);
     if (aa.length === 0 || bb.length === 0) {

--- a/src/match-detection/features/bib/issn.js
+++ b/src/match-detection/features/bib/issn.js
@@ -37,7 +37,6 @@ export default () => ({
       return /^[0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9X]$/u.test(val);
     }
   },
-  // eslint-disable-next-line max-statements
   compare: (aa, bb) => {
     debugData(`Comparing ISSN sets ${JSON.stringify(aa)} and ${JSON.stringify(bb)}`);
     if (aa.length === 0 || bb.length === 0) {

--- a/src/match-detection/features/bib/language.js
+++ b/src/match-detection/features/bib/language.js
@@ -1,4 +1,3 @@
-
 import createDebugLogger from 'debug';
 
 import {MarcRecord} from '@natlibfi/marc-record';
@@ -37,7 +36,6 @@ export default () => ({
     // Should we return all the fields, or just the relevant fields?
     return [clonedRecord.fields, label];
   },
-  // eslint-disable-next-line max-statements
   compare: (aa, bb) => {
     const [a, aLabel] = aa;
     const [b, bLabel] = bb;

--- a/src/match-detection/features/bib/media-type.js
+++ b/src/match-detection/features/bib/media-type.js
@@ -1,6 +1,3 @@
-/* eslint-disable max-statements */
-
-
 import createDebugLogger from 'debug';
 
 const debug = createDebugLogger('@natlibfi/melinda-record-matching:match-detection:features:media-type');

--- a/src/match-detection/features/bib/publication-time-allow-cons-years-multi.js
+++ b/src/match-detection/features/bib/publication-time-allow-cons-years-multi.js
@@ -147,7 +147,6 @@ export default () => ({
     }
 
   },
-  // eslint-disable-next-line max-statements
   compare: (a, b) => {
     const debug = createDebugLogger('@natlibfi/melinda-record-matching:match-detection:features/bib/publication-time-allow-cons-years-multi');
     debug(`Comparing ${JSON.stringify(a)} to ${JSON.stringify(b)}`);

--- a/src/match-detection/features/bib/standard-identifier-factory.js
+++ b/src/match-detection/features/bib/standard-identifier-factory.js
@@ -1,5 +1,3 @@
-/* eslint-disable max-statements */
-
 import createDebugLogger from 'debug';
 import {extractSubfieldsFromField, uniqueSubfields} from '../../../matching-utils.js';
 

--- a/src/match-detection/features/index.js
+++ b/src/match-detection/features/index.js
@@ -1,3 +1,5 @@
 
+import * as auth from './auth/index.js';
 import * as bib from './bib/index.js';
-export {bib};
+
+export {auth, bib};

--- a/src/match-detection/index.test.js
+++ b/src/match-detection/index.test.js
@@ -20,13 +20,7 @@ describe('match-detection', () => {
     fixura: {
       reader: READERS.JSON
     },
-    callback: ({getFixture, options, expectedResults, array, enabled = true}) => {
-
-      if (!enabled) {
-        debug(`*** DISABLED TEST! ***`);
-        return;
-      }
-
+    callback: ({getFixture, options, expectedResults, array}) => {
       const detect = createDetectionInterface(formatOptions());
       const recordA = new MarcRecord(getFixture('recordA.json'), {subfieldValues: false});
       debugData(inspect(recordA));

--- a/test-fixtures/candidate-search/query-list/auth/yso/01/metadata.json
+++ b/test-fixtures/candidate-search/query-list/auth/yso/01/metadata.json
@@ -1,0 +1,15 @@
+{
+  "description": "Should generate auth id query (note that 024$a is actually a seko id, not an yso one",
+  "type": "authStandardIdentifiers",
+  "expectedQuery": ["melinda.urx=\"http://urn.fi/urn:nbn:fi:au:seko:00445\""],
+  "inputRecord": {
+    "leader": "02518cam a2200745zi 4500",
+    "fields": [
+      { "tag": "001", "value": "000019643" },
+      { "tag": "024", "ind1": " ", "ind2": " ", "subfields": [
+        { "code": "a", "value": "http://urn.fi/urn:nbn:fi:au:seko:00445" },
+        { "code": "2", "value": "urn" }
+      ]}
+    ]
+  }
+}

--- a/test-fixtures/candidate-search/query-list/auth/yso/01/metadata.json
+++ b/test-fixtures/candidate-search/query-list/auth/yso/01/metadata.json
@@ -1,6 +1,6 @@
 {
   "description": "Should generate auth id query (note that 024$a is actually a seko id, not an yso one",
-  "type": "authStandardIdentifiers",
+  "type": "authURX",
   "expectedQuery": ["melinda.urx=\"http://urn.fi/urn:nbn:fi:au:seko:00445\""],
   "inputRecord": {
     "leader": "02518cam a2200745zi 4500",

--- a/test-fixtures/candidate-search/query-list/auth/yso/02/metadata.json
+++ b/test-fixtures/candidate-search/query-list/auth/yso/02/metadata.json
@@ -1,0 +1,11 @@
+{
+  "description": "Should generate auth id query (note that 024$a is actually a seko id, not an yso one",
+  "type": "authStandardIdentifiers",
+  "expectedQuery": [],
+  "inputRecord": {
+    "leader": "02518cam a2200745zi 4500",
+    "fields": [
+      { "tag": "001", "value": "000019643" }
+    ]
+  }
+}

--- a/test-fixtures/candidate-search/query-list/auth/yso/02/metadata.json
+++ b/test-fixtures/candidate-search/query-list/auth/yso/02/metadata.json
@@ -1,6 +1,6 @@
 {
   "description": "Should generate auth id query (note that 024$a is actually a seko id, not an yso one",
-  "type": "authStandardIdentifiers",
+  "type": "authURX",
   "expectedQuery": [],
   "inputRecord": {
     "leader": "02518cam a2200745zi 4500",

--- a/test-fixtures/candidate-search/query-list/auth/yso/03/metadata.json
+++ b/test-fixtures/candidate-search/query-list/auth/yso/03/metadata.json
@@ -1,0 +1,19 @@
+{
+  "description": "Should accept both f024 contents",
+  "type": "authStandardIdentifiers",
+  "expectedQuery": ["melinda.urx=\"http://urn.fi/urn:nbn:fi:au:seko:00445\" or melinda.urx=\"http://urn.fi/urn:nbn:fi:au:seko:00456\""],
+  "inputRecord": {
+    "leader": "02518cam a2200745zi 4500",
+    "fields": [
+      { "tag": "001", "value": "000019643" },
+      { "tag": "024", "ind1": " ", "ind2": " ", "subfields": [
+        { "code": "a", "value": "http://urn.fi/urn:nbn:fi:au:seko:00445" },
+        { "code": "2", "value": "urn" }
+      ]},
+      { "tag": "024", "ind1": " ", "ind2": " ", "subfields": [
+        { "code": "a", "value": "http://urn.fi/urn:nbn:fi:au:seko:00456" },
+        { "code": "2", "value": "urn" }
+      ]}
+    ]
+  }
+}

--- a/test-fixtures/candidate-search/query-list/auth/yso/03/metadata.json
+++ b/test-fixtures/candidate-search/query-list/auth/yso/03/metadata.json
@@ -1,6 +1,6 @@
 {
   "description": "Should accept both f024 contents",
-  "type": "authStandardIdentifiers",
+  "type": "authURX",
   "expectedQuery": ["melinda.urx=\"http://urn.fi/urn:nbn:fi:au:seko:00445\" or melinda.urx=\"http://urn.fi/urn:nbn:fi:au:seko:00456\""],
   "inputRecord": {
     "leader": "02518cam a2200745zi 4500",

--- a/test-fixtures/candidate-search/query-list/auth/yso/04/metadata.json
+++ b/test-fixtures/candidate-search/query-list/auth/yso/04/metadata.json
@@ -1,0 +1,17 @@
+{
+  "description": "Should generate query with both f024$a identifiers",
+  "comment": "Note that f024$a is actually a non-repeatable subfield, but we tolerate that error here",
+  "type": "authStandardIdentifiers",
+  "expectedQuery": ["melinda.urx=\"http://urn.fi/urn:nbn:fi:au:seko:00445\" or melinda.urx=\"http://urn.fi/urn:nbn:fi:au:seko:00666\""],
+  "inputRecord": {
+    "leader": "02518cam a2200745zi 4500",
+    "fields": [
+      { "tag": "001", "value": "000019643" },
+      { "tag": "024", "ind1": " ", "ind2": " ", "subfields": [
+        { "code": "a", "value": "http://urn.fi/urn:nbn:fi:au:seko:00445" },
+        { "code": "a", "value": "http://urn.fi/urn:nbn:fi:au:seko:00666" },
+        { "code": "2", "value": "urn" }
+      ]}
+    ]
+  }
+}

--- a/test-fixtures/candidate-search/query-list/auth/yso/04/metadata.json
+++ b/test-fixtures/candidate-search/query-list/auth/yso/04/metadata.json
@@ -1,7 +1,7 @@
 {
   "description": "Should generate query with both f024$a identifiers",
   "comment": "Note that f024$a is actually a non-repeatable subfield, but we tolerate that error here",
-  "type": "authStandardIdentifiers",
+  "type": "authURX",
   "expectedQuery": ["melinda.urx=\"http://urn.fi/urn:nbn:fi:au:seko:00445\" or melinda.urx=\"http://urn.fi/urn:nbn:fi:au:seko:00666\""],
   "inputRecord": {
     "leader": "02518cam a2200745zi 4500",

--- a/test-fixtures/candidate-search/query-list/bib/hostComponents/04/metadata.json
+++ b/test-fixtures/candidate-search/query-list/bib/hostComponents/04/metadata.json
@@ -1,6 +1,6 @@
 {
   "description": "DISABLED: Should generate host record query (several sf $w)",
-  "enabled": false,
+  "skip": true,
   "type": "bibHostComponents",
   "expectedQuery": ["melinda.partsofhost=12345"],
   "inputRecord": {

--- a/test-fixtures/candidate-search/query-list/bib/hostComponents/05/metadata.json
+++ b/test-fixtures/candidate-search/query-list/bib/hostComponents/05/metadata.json
@@ -1,6 +1,6 @@
 {
   "description": "DISABLED: Should generate host record query (several f773)",
-  "enabled": false,
+  "skip": true,
   "type": "bibHostComponents",
   "expectedQuery": ["melinda.partsofhost=12345"],
   "inputRecord": {

--- a/test-fixtures/candidate-search/query-list/bib/sourceIds/03/metadata.json
+++ b/test-fixtures/candidate-search/query-list/bib/sourceIds/03/metadata.json
@@ -1,6 +1,6 @@
 {
   "description": "Should create query from two SIDs",
-  "enabled": true,
+  "skip": false,
   "type": "bibSourceIds",
   "expectedQuery": ["melinda.sourceid=9999999helka or melinda.sourceid=9999999testi"],
   "inputRecord": {

--- a/test-fixtures/candidate-search/query-list/bib/sourceIds/04/metadata.json
+++ b/test-fixtures/candidate-search/query-list/bib/sourceIds/04/metadata.json
@@ -1,6 +1,6 @@
 {
   "description": "Do not create sourceId query if there's no valid SID (wrong subfield)",
-  "enabled": true,
+  "skip": false,
   "type": "bibSourceIds",
   "expectedQuery": [],
   "inputRecord": {

--- a/test-fixtures/candidate-search/query-list/bib/sourceIds/05/metadata.json
+++ b/test-fixtures/candidate-search/query-list/bib/sourceIds/05/metadata.json
@@ -1,6 +1,6 @@
 {
   "description": "Should normalize source prefix out of source-ID string",
-  "enabled": true,
+  "skip": false,
   "type": "bibSourceIds",
   "expectedQuery": ["melinda.sourceid=1077305sata"],
   "inputRecord": {

--- a/test-fixtures/candidate-search/query-list/bib/sourceIds/06/metadata.json
+++ b/test-fixtures/candidate-search/query-list/bib/sourceIds/06/metadata.json
@@ -1,6 +1,6 @@
 {
   "description": "Should normalize hyphens out of source string (fSID $b)",
-  "enabled": true,
+  "skip": false,
   "type": "bibSourceIds",
   "expectedQuery": ["melinda.sourceid=VER999999FIKV"],
   "inputRecord": {

--- a/test-fixtures/candidate-search/query-list/bib/sourceIds/07/metadata.json
+++ b/test-fixtures/candidate-search/query-list/bib/sourceIds/07/metadata.json
@@ -1,6 +1,6 @@
 {
   "description": "Should quote SRU candidate search strings that include slashes",
-  "enabled": true,
+  "skip": false,
   "type": "bibSourceIds",
   "expectedQuery": ["melinda.sourceid=\"/10024/508126REPO_THESEUS\""],
   "inputRecord": {

--- a/test-fixtures/candidate-search/query-list/bib/title/05/metadata.json
+++ b/test-fixtures/candidate-search/query-list/bib/title/05/metadata.json
@@ -1,6 +1,6 @@
 {
   "description": "Should generate title query including the translated name in the $b subtitle (despite punc: =), since title is so short",
-  "only": true,
+  "only": false,
   "type": "bibTitle",
   "expectedQuery": ["dc.title=\"^E 15 etanoita ja etanolia sinne*\""],
   "inputRecord": {

--- a/test-fixtures/candidate-search/query-list/bib/title/06/metadata.json
+++ b/test-fixtures/candidate-search/query-list/bib/title/06/metadata.json
@@ -1,6 +1,6 @@
 {
   "description": "DISABLED: Should generate title query from field using a filing indicator",
-  "enabled": false,
+  "skip": true,
   "type": "bibTitle",
   "expectedQuery": ["dc.title=\"^hobbit or There and back again*\""],
   "inputRecord": {

--- a/test-fixtures/candidate-search/query-list/bib/title/20/metadata.json
+++ b/test-fixtures/candidate-search/query-list/bib/title/20/metadata.json
@@ -1,6 +1,6 @@
 {
   "description": "Should generate title query *excluding* the translated name in the $b subtitle (since punc: =)",
-  "only": true,
+  "only": false,
   "type": "bibTitle",
   "expectedQuery": ["dc.title=\"^Eurooppa 15*\""],
   "inputRecord": {

--- a/test-fixtures/candidate-search/query-list/bib/titleAuthor/06/metadata.json
+++ b/test-fixtures/candidate-search/query-list/bib/titleAuthor/06/metadata.json
@@ -1,6 +1,5 @@
 {
   "description": "DISABLED: Should generate titleAuthor query from field using a filing indicator",
-  "enabled": false,
   "only": false,
   "skip": true,
   "type": "bibTitleAuthor",

--- a/test-fixtures/index/18/expectedMatches.json
+++ b/test-fixtures/index/18/expectedMatches.json
@@ -1,0 +1,43 @@
+[
+  {
+    "probability": 1.0,
+    "candidate": {
+      "id": "000019641",
+      "record": {
+        "leader": "02518cam a2200745zi 4500",
+        "fields": [
+          {
+            "tag": "001",
+            "value": "000019641"
+          },
+          {
+            "tag": "020",
+            "ind1": " ",
+            "ind2": " ",
+            "subfields": [
+              {
+                "code": "a",
+                "value": "978-952-62-2477-0"
+              }
+            ]
+          },
+          {
+            "tag": "245",
+            "ind1": "1",
+            "ind2": " ",
+            "subfields": [
+              {
+                "code": "a",
+                "value": "foo  ."
+              },
+              {
+                "code": "b",
+                "value": "bar"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+]

--- a/test-fixtures/index/18/expectedMatches.json
+++ b/test-fixtures/index/18/expectedMatches.json
@@ -2,41 +2,25 @@
   {
     "probability": 1.0,
     "candidate": {
-      "id": "000019641",
+      "id": "000223401",
       "record": {
-        "leader": "02518cam a2200745zi 4500",
+        "leader": "02518czm a2200745zi 4500",
         "fields": [
-          {
-            "tag": "001",
-            "value": "000019641"
-          },
-          {
-            "tag": "020",
-            "ind1": " ",
-            "ind2": " ",
-            "subfields": [
-              {
-                "code": "a",
-                "value": "978-952-62-2477-0"
-              }
-            ]
-          },
-          {
-            "tag": "245",
-            "ind1": "1",
-            "ind2": " ",
-            "subfields": [
-              {
-                "code": "a",
-                "value": "foo  ."
-              },
-              {
-                "code": "b",
-                "value": "bar"
-              }
-            ]
-          }
-        ]
+        {"tag": "001", "value": "000223401"},
+        { "tag": "024", "ind1": " ", "ind2": "7", "subfields": [
+          { "code": "a", "value": "p13299" },
+          { "code": "2", "value": "uri" }
+        ]},
+        { "tag": "040", "ind1": " ", "ind2": "7", "subfields": [
+          { "code": "a", "value": "FI-NL" },
+          { "code": "b", "value": "fin" },
+          { "code": "f", "value": "yso/fin" }
+        ]},
+        { "tag": "150", "ind1": " ", "ind2": "7", "subfields": [
+          { "code": "a", "value": "laiturit" },
+          { "code": "2", "value": "yso/fin" },
+          { "code": "0", "value": "http://www.yso.fi/onto/yso/p13299" }
+        ]}]
       }
     }
   }

--- a/test-fixtures/index/18/inputRecord.json
+++ b/test-fixtures/index/18/inputRecord.json
@@ -1,0 +1,26 @@
+{
+  "leader": "02518czm a2200745zi 4500",
+  "fields": [
+    {
+      "tag": "001",
+      "value": "000019640"
+    },
+    { "tag": "024", "ind1": " ", "ind2": "7", "subfields": [
+        { "code": "a", "value": "http://www.yso.fi/onto/yso/p13299" },
+        { "code": "2", "value": "uri" }
+      ]
+    },
+    { "tag": "040", "ind1": " ", "ind2": "7", "subfields": [
+        { "code": "a", "value": "FI-NL" },
+        { "code": "b", "value": "fin" },
+        { "code": "f", "value": "yso/fin" }
+      ]
+    },
+    { "tag": "150", "ind1": " ", "ind2": "7", "subfields": [
+        { "code": "a", "value": "laiturit" },
+        { "code": "2", "value": "yso/fin" },
+        { "code": "a", "value": "http://www.yso.fi/onto/yso/p13299" }
+      ]
+    }
+  ]
+}

--- a/test-fixtures/index/18/inputRecord.json
+++ b/test-fixtures/index/18/inputRecord.json
@@ -3,10 +3,11 @@
   "fields": [
     {
       "tag": "001",
-      "value": "000019640"
+      "value": "000000666"
     },
     { "tag": "024", "ind1": " ", "ind2": "7", "subfields": [
-        { "code": "a", "value": "http://www.yso.fi/onto/yso/p13299" },
+        { "code": "a", "value": "p13299" },
+        { "code": "q", "value": "$a should actually be http://www.yso.fi/onto/yso/p13299 but it gets url-encoded, and then url-encoding breaks mock"},
         { "code": "2", "value": "uri" }
       ]
     },
@@ -19,7 +20,7 @@
     { "tag": "150", "ind1": " ", "ind2": "7", "subfields": [
         { "code": "a", "value": "laiturit" },
         { "code": "2", "value": "yso/fin" },
-        { "code": "a", "value": "http://www.yso.fi/onto/yso/p13299" }
+        { "code": "0", "value": "http://www.yso.fi/onto/yso/p13299" }
       ]
     }
   ]

--- a/test-fixtures/index/18/metadata.json
+++ b/test-fixtures/index/18/metadata.json
@@ -23,15 +23,15 @@
   "requests": [
     {
       "method": "get",
-      "url": "/?operation=searchRetrieve&query=melinda.urx%3Dhttp://www.yso.fi/onto/yso/p13299&startRecord=1&version=2.0&maximumRecords=1",
+      "url": "/?operation=searchRetrieve&query=melinda.urx%3Dp13299&startRecord=1&version=2.0&maximumRecords=1",
       "status": 200
     },
     {
       "method": "get",
-      "url": "/?operation=searchRetrieve&query=melinda.urx%3Dhttp://www.yso.fi/onto/yso/p13299&startRecord=2&version=2.0&maximumRecords=1",
+      "url": "/?operation=searchRetrieve&query=melinda.urx%3Dp13299&startRecord=2&version=2.0&maximumRecords=1",
       "status": 200
     }
   ],
-  "skip": true,
+  "skip": false,
   "only": false
 }

--- a/test-fixtures/index/18/metadata.json
+++ b/test-fixtures/index/18/metadata.json
@@ -1,0 +1,37 @@
+{
+  "description": "Should find matches for AUTH. NOT WORKING YET! DISABLED!",
+  "options": {
+    "search": {
+      "searchSpec": ["authStandardIdentifiers"],
+      "url": "http://foo.bar",
+      "maxRecordsPerRequest": 1
+    },
+    "detection": {
+      "strategy": {
+        "type": "auth",
+        "features": [
+          "yso"
+        ]
+      }
+    },
+    "maxMatches": 2,
+    "maxCandidates": 1
+  },
+  "expectedMatchStatus": false,
+  "expectedStopReason": "maxCandidates",
+  "expectedCandidateCount": 1,
+  "requests": [
+    {
+      "method": "get",
+      "url": "/?operation=searchRetrieve&query=melinda.urx%3Dhttp://www.yso.fi/onto/yso/p13299&startRecord=1&version=2.0&maximumRecords=1",
+      "status": 200
+    },
+    {
+      "method": "get",
+      "url": "/?operation=searchRetrieve&query=melinda.urx%3Dhttp://www.yso.fi/onto/yso/p13299&startRecord=2&version=2.0&maximumRecords=1",
+      "status": 200
+    }
+  ],
+  "skip": true,
+  "only": false
+}

--- a/test-fixtures/index/18/metadata.json
+++ b/test-fixtures/index/18/metadata.json
@@ -2,7 +2,7 @@
   "description": "Should find matches for AUTH. NOT WORKING YET! DISABLED!",
   "options": {
     "search": {
-      "searchSpec": ["authStandardIdentifiers"],
+      "searchSpec": ["authURX"],
       "url": "http://foo.bar",
       "maxRecordsPerRequest": 1
     },

--- a/test-fixtures/index/18/response01.xml
+++ b/test-fixtures/index/18/response01.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse">
+  <zs:numberOfRecords>2</zs:numberOfRecords>
+  <zs:records>
+    <zs:record>
+      <zs:recordSchema>info:srw/schema/1/foo</zs:recordSchema>
+      <zs:recordXMLEscaping>xml</zs:recordXMLEscaping>
+      <zs:recordData>
+        <record xmlns="http://www.loc.gov/MARC21/slim">
+          <leader>02518cam a2200745zi 4500</leader>
+          <controlfield tag="001">000019641</controlfield>>
+          <datafield tag="020" ind1=" " ind2=" ">
+            <subfield code="a">978-952-62-2477-0</subfield>
+          </datafield>
+          <datafield tag="245" ind1="1" ind2=" ">
+            <subfield code="a">foo  .</subfield>
+            <subfield code="b">bar</subfield>
+          </datafield>
+        </record>
+      </zs:recordData>
+      <zs:recordPosition>1</zs:recordPosition>
+    </zs:record>
+  </zs:records>
+</zs:searchRetrieveResponse>

--- a/test-fixtures/index/18/response01.xml
+++ b/test-fixtures/index/18/response01.xml
@@ -7,14 +7,21 @@
       <zs:recordXMLEscaping>xml</zs:recordXMLEscaping>
       <zs:recordData>
         <record xmlns="http://www.loc.gov/MARC21/slim">
-          <leader>02518cam a2200745zi 4500</leader>
-          <controlfield tag="001">000019641</controlfield>>
-          <datafield tag="020" ind1=" " ind2=" ">
-            <subfield code="a">978-952-62-2477-0</subfield>
+          <leader>02518czm a2200745zi 4500</leader>
+          <controlfield tag="001">000223401</controlfield>
+          <datafield tag="024" ind1=" " ind2="7">
+            <subfield code="a">p13299</subfield>
+            <subfield code="2">uri</subfield>
           </datafield>
-          <datafield tag="245" ind1="1" ind2=" ">
-            <subfield code="a">foo  .</subfield>
-            <subfield code="b">bar</subfield>
+          <datafield tag="040" ind1=" " ind2="7">
+            <subfield code="a">FI-NL</subfield>
+            <subfield code="b">fin</subfield>
+            <subfield code="f">yso/fin</subfield>
+          </datafield>
+          <datafield tag="150" ind1=" " ind2="7">
+            <subfield code="a">laiturit</subfield>
+            <subfield code="2">yso/fin</subfield>
+            <subfield code="0">http://www.yso.fi/onto/yso/p13299</subfield>
           </datafield>
         </record>
       </zs:recordData>

--- a/test-fixtures/index/18/response02.xml
+++ b/test-fixtures/index/18/response02.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<zs:searchRetrieveResponse xmlns:zs="http://docs.oasis-open.org/ns/search-ws/sruResponse">
+  <zs:numberOfRecords>2</zs:numberOfRecords>
+  <zs:records>
+    <zs:record>
+      <zs:recordSchema>info:srw/schema/1/foo</zs:recordSchema>
+      <zs:recordXMLEscaping>xml</zs:recordXMLEscaping>
+      <zs:recordData>
+        <record xmlns="http://www.loc.gov/MARC21/slim">
+          <leader>02518cam a2200745zi 4500</leader>
+          <controlfield tag="001">000019642</controlfield>>
+          <datafield tag="020" ind1=" " ind2=" ">
+            <subfield code="a">978-952-62-2478-0</subfield>
+          </datafield>
+          <datafield tag="245" ind1="1" ind2=" ">
+            <subfield code="a">foo  .</subfield>
+            <subfield code="b">bar</subfield>
+          </datafield>
+        </record>
+      </zs:recordData>
+      <zs:recordPosition>2</zs:recordPosition>
+    </zs:record>
+  </zs:records>
+</zs:searchRetrieveResponse>

--- a/test-fixtures/index/18/response02.xml
+++ b/test-fixtures/index/18/response02.xml
@@ -7,14 +7,21 @@
       <zs:recordXMLEscaping>xml</zs:recordXMLEscaping>
       <zs:recordData>
         <record xmlns="http://www.loc.gov/MARC21/slim">
-          <leader>02518cam a2200745zi 4500</leader>
-          <controlfield tag="001">000019642</controlfield>>
-          <datafield tag="020" ind1=" " ind2=" ">
-            <subfield code="a">978-952-62-2478-0</subfield>
+          <leader>02518czm a2200745zi 4500</leader>
+          <controlfield tag="001">000252365</controlfield>
+          <datafield tag="024" ind1=" " ind2="7">
+            <subfield code="a">p13299</subfield>
+            <subfield code="2">uri</subfield>
           </datafield>
-          <datafield tag="245" ind1="1" ind2=" ">
-            <subfield code="a">foo  .</subfield>
-            <subfield code="b">bar</subfield>
+          <datafield tag="040" ind1=" " ind2="7">
+            <subfield code="a">FI-NL</subfield>
+            <subfield code="b">fin</subfield>
+            <subfield code="f">yso/fin</subfield>
+          </datafield>
+          <datafield tag="150" ind1=" " ind2="7">
+            <subfield code="a">bryggor</subfield>
+            <subfield code="2">yso/swe</subfield>
+            <subfield code="0">http://www.yso.fi/onto/yso/p13299</subfield>
           </datafield>
         </record>
       </zs:recordData>

--- a/test-fixtures/match-detection/features/auth/yso/01/metadata.json
+++ b/test-fixtures/match-detection/features/auth/yso/01/metadata.json
@@ -1,0 +1,27 @@
+{
+    "description": "Extracts multiple IDs from f024$as, and extracts thesaurus from 040$f",
+    "feature": "yso",
+    "type": "extract",
+    "expectedFeatures":
+      {
+        "identifiers": ["id1", "id2"],
+        "thesaurus": "yso/fin"
+      }
+    ,
+    "inputRecord": {
+      "leader": "02518cam a2200745zi 4500",
+      "fields": [
+        { "tag": "001", "value": "record-id" },
+        { "tag": "024", "subfields": [
+          {"code": "a", "value": "id1"}
+        ]},
+        { "tag": "024", "subfields": [
+          {"code": "a", "value": "id2"}
+        ]},
+        { "tag": "040", "subfields": [
+          {"code": "a", "value": "FI-NL"},
+          {"code": "f", "value": "yso/fin"}
+        ]}
+      ]
+    }
+  }

--- a/test-fixtures/match-detection/features/auth/yso/01/metadata.json
+++ b/test-fixtures/match-detection/features/auth/yso/01/metadata.json
@@ -13,10 +13,19 @@
       "fields": [
         { "tag": "001", "value": "record-id" },
         { "tag": "024", "subfields": [
-          {"code": "a", "value": "id1"}
+          {"code": "a", "value": "id0"}
         ]},
         { "tag": "024", "subfields": [
-          {"code": "a", "value": "id2"}
+          {"code": "a", "value": "id1"},
+          {"code": "2", "value": "urn"}
+        ]},
+        { "tag": "024", "subfields": [
+          {"code": "a", "value": "id2"},
+          {"code": "2", "value": "urn"}
+        ]},
+        { "tag": "024", "subfields": [
+          {"code": "a", "value": "id2"},
+          {"code": "2", "value": "finaf"}
         ]},
         { "tag": "040", "subfields": [
           {"code": "a", "value": "FI-NL"},

--- a/test-fixtures/match-detection/features/auth/yso/02/metadata.json
+++ b/test-fixtures/match-detection/features/auth/yso/02/metadata.json
@@ -1,0 +1,17 @@
+{
+    "description": "Tries to extract an ID from f024$as and thesaurus from 041$f, but there is none",
+    "feature": "yso",
+    "type": "extract",
+    "expectedFeatures":
+      {
+        "identifiers": [],
+        "thesaurus": null
+      }
+    ,
+    "inputRecord": {
+      "leader": "02518cam a2200745zi 4500",
+      "fields": [
+        { "tag": "001", "value": "record-id" }
+      ]
+    }
+  }

--- a/test-fixtures/match-detection/features/auth/yso/02/metadata.json
+++ b/test-fixtures/match-detection/features/auth/yso/02/metadata.json
@@ -1,5 +1,5 @@
 {
-    "description": "Tries to extract an ID from f024$as and thesaurus from 041$f, but there is none",
+    "description": "Tries to extract an ID from f024$as and thesaurus from 040$f, but there is none",
     "feature": "yso",
     "type": "extract",
     "expectedFeatures":

--- a/test-fixtures/match-detection/features/auth/yso/03/metadata.json
+++ b/test-fixtures/match-detection/features/auth/yso/03/metadata.json
@@ -1,0 +1,17 @@
+{
+    "description": "Tries to extract an ID from f024$as and thesaurus from 041$f, but there is none",
+    "feature": "yso",
+    "type": "extract",
+    "expectedFeatures":
+      {
+        "identifiers": [],
+        "thesaurus": null
+      }
+    ,
+    "inputRecord": {
+      "leader": "02518cam a2200745zi 4500",
+      "fields": [
+        { "tag": "001", "value": "record-id" }
+      ]
+    }
+  }

--- a/test-fixtures/match-detection/features/bib/f773/13/metadata.json
+++ b/test-fixtures/match-detection/features/bib/f773/13/metadata.json
@@ -21,5 +21,5 @@
     }
   ],
   "skip": false,
-  "only": true
+  "only": false
 }

--- a/test-fixtures/match-detection/features/bib/language/22/metadata.json
+++ b/test-fixtures/match-detection/features/bib/language/22/metadata.json
@@ -14,5 +14,5 @@
     ],
     "B"],
   "skip": false,
-  "only": true
+  "only": false
 }

--- a/test-fixtures/match-detection/index/19/metadata.json
+++ b/test-fixtures/match-detection/index/19/metadata.json
@@ -1,0 +1,17 @@
+{
+  "description": "YSO: Should not detect a match (no ids)",
+  "options": {
+    "strategy": {
+      "type": "auth",
+      "features": [
+        "yso"
+      ]
+    }
+  },
+  "expectedResults": {
+    "match": false,
+    "probability": 0
+  },
+  "skip": false,
+  "only": false
+}

--- a/test-fixtures/match-detection/index/19/recordA.json
+++ b/test-fixtures/match-detection/index/19/recordA.json
@@ -1,0 +1,6 @@
+{
+  "leader": "01005czm a22003138i 4500",
+  "fields": [
+    { "tag": "001", "value": "recordA" }
+  ]
+}

--- a/test-fixtures/match-detection/index/19/recordB.json
+++ b/test-fixtures/match-detection/index/19/recordB.json
@@ -1,0 +1,6 @@
+{
+  "leader": "01005czm a22003138i 4500",
+  "fields": [
+    { "tag": "001", "value": "recordB" }
+  ]
+}

--- a/test-fixtures/match-detection/index/20/metadata.json
+++ b/test-fixtures/match-detection/index/20/metadata.json
@@ -1,0 +1,17 @@
+{
+  "description": "YSO: Should not detect a match (different IDs)",
+  "options": {
+    "strategy": {
+      "type": "auth",
+      "features": [
+        "yso"
+      ]
+    }
+  },
+  "expectedResults": {
+    "match": false,
+    "probability": 0
+  },
+  "skip": false,
+  "only": false
+}

--- a/test-fixtures/match-detection/index/20/recordA.json
+++ b/test-fixtures/match-detection/index/20/recordA.json
@@ -1,0 +1,9 @@
+{
+  "leader": "01005czm a22003138i 4500",
+  "fields": [
+    { "tag": "001", "value": "recordA" },
+    { "tag": "024", "subfields": [
+      {"code": "a", "value": "id321"}
+    ]}
+  ]
+}

--- a/test-fixtures/match-detection/index/20/recordB.json
+++ b/test-fixtures/match-detection/index/20/recordB.json
@@ -1,0 +1,9 @@
+{
+  "leader": "01005czm a22003138i 4500",
+  "fields": [
+    { "tag": "001", "value": "recordB" },
+    { "tag": "024", "subfields": [
+      {"code": "a", "value": "id123"}
+    ]}
+  ]
+}

--- a/test-fixtures/match-detection/index/21/metadata.json
+++ b/test-fixtures/match-detection/index/21/metadata.json
@@ -1,0 +1,17 @@
+{
+  "description": "YSO: Should fail (identical IDs found, but no thesaurus)",
+  "options": {
+    "strategy": {
+      "type": "auth",
+      "features": [
+        "yso"
+      ]
+    }
+  },
+  "expectedResults": {
+    "match": false,
+    "probability": 0
+  },
+  "skip": false,
+  "only": true
+}

--- a/test-fixtures/match-detection/index/21/metadata.json
+++ b/test-fixtures/match-detection/index/21/metadata.json
@@ -13,5 +13,5 @@
     "probability": 0
   },
   "skip": false,
-  "only": true
+  "only": false
 }

--- a/test-fixtures/match-detection/index/21/recordA.json
+++ b/test-fixtures/match-detection/index/21/recordA.json
@@ -1,0 +1,9 @@
+{
+  "leader": "01005czm a22003138i 4500",
+  "fields": [
+    { "tag": "001", "value": "recordA" },
+    { "tag": "024", "subfields": [
+      {"code": "a", "value": "id321"}
+    ]}
+  ]
+}

--- a/test-fixtures/match-detection/index/21/recordB.json
+++ b/test-fixtures/match-detection/index/21/recordB.json
@@ -1,0 +1,9 @@
+{
+  "leader": "01005czm a22003138i 4500",
+  "fields": [
+    { "tag": "001", "value": "recordB" },
+    { "tag": "024", "subfields": [
+      {"code": "a", "value": "id321"}
+    ]}
+  ]
+}

--- a/test-fixtures/match-detection/index/22/metadata.json
+++ b/test-fixtures/match-detection/index/22/metadata.json
@@ -1,0 +1,17 @@
+{
+  "description": "YSO: Should succeed (identical IDs found, but no thesaurus)",
+  "options": {
+    "strategy": {
+      "type": "auth",
+      "features": [
+        "yso"
+      ]
+    }
+  },
+  "expectedResults": {
+    "match": true,
+    "probability": 1
+  },
+  "skip": false,
+  "only": true
+}

--- a/test-fixtures/match-detection/index/22/metadata.json
+++ b/test-fixtures/match-detection/index/22/metadata.json
@@ -13,5 +13,5 @@
     "probability": 1
   },
   "skip": false,
-  "only": true
+  "only": false
 }

--- a/test-fixtures/match-detection/index/22/metadata.json
+++ b/test-fixtures/match-detection/index/22/metadata.json
@@ -1,5 +1,5 @@
 {
-  "description": "YSO: Should succeed (identical IDs found, but no thesaurus)",
+  "description": "YSO: Should succeed (identical IDs and thesaurus found)",
   "options": {
     "strategy": {
       "type": "auth",

--- a/test-fixtures/match-detection/index/22/recordA.json
+++ b/test-fixtures/match-detection/index/22/recordA.json
@@ -1,0 +1,12 @@
+{
+  "leader": "01005czm a22003138i 4500",
+  "fields": [
+    { "tag": "001", "value": "recordA" },
+    { "tag": "024", "subfields": [
+      {"code": "a", "value": "id321"}
+    ]},
+    { "tag": "040", "subfields": [
+      {"code": "f", "value": "yso/fin"}
+    ]}
+  ]
+}

--- a/test-fixtures/match-detection/index/22/recordA.json
+++ b/test-fixtures/match-detection/index/22/recordA.json
@@ -3,7 +3,8 @@
   "fields": [
     { "tag": "001", "value": "recordA" },
     { "tag": "024", "subfields": [
-      {"code": "a", "value": "id321"}
+      {"code": "a", "value": "id321"},
+      {"code": "2", "value": "urn"}
     ]},
     { "tag": "040", "subfields": [
       {"code": "f", "value": "yso/fin"}

--- a/test-fixtures/match-detection/index/22/recordB.json
+++ b/test-fixtures/match-detection/index/22/recordB.json
@@ -1,0 +1,12 @@
+{
+  "leader": "01005czm a22003138i 4500",
+  "fields": [
+    { "tag": "001", "value": "recordB" },
+    { "tag": "024", "subfields": [
+      {"code": "a", "value": "id321"}
+    ]},
+    { "tag": "040", "subfields": [
+      {"code": "f", "value": "yso/fin"}
+    ]}
+  ]
+}

--- a/test-fixtures/match-detection/index/22/recordB.json
+++ b/test-fixtures/match-detection/index/22/recordB.json
@@ -3,7 +3,8 @@
   "fields": [
     { "tag": "001", "value": "recordB" },
     { "tag": "024", "subfields": [
-      {"code": "a", "value": "id321"}
+      {"code": "a", "value": "id321"},
+      {"code": "2", "value": "urn"}
     ]},
     { "tag": "040", "subfields": [
       {"code": "f", "value": "yso/fin"}


### PR DESCRIPTION
- Initial support SRU queries and matching for YSO authority records
-- works probably for SLM and maybe for MTS as well, but they are yet untested)
-- SRU query is done with auth records f024$a
-- Matching uses both f024$a and f040$f. The latter is used to check the input language (resolves yso/fin vs yso/swe differences)  
- update deps (force uuid "^14.0.0" due to security issues in some deps)