### PR TITLE
Isbn: kokonaisuus-isbn:t pois, jos tavis-isbn löytyy (MET-803 ja MET-804)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
 			"version": "5.1.0",
 			"license": "MIT",
 			"dependencies": {
-				"@natlibfi/marc-record": "^10.0.1",
-				"@natlibfi/marc-record-serializers": "^11.0.2",
+				"@natlibfi/marc-record": "^10.0.2",
+				"@natlibfi/marc-record-serializers": "^11.0.3",
 				"@natlibfi/marc-record-validators-melinda": "^12.0.15",
 				"@natlibfi/melinda-commons": "^14.0.2",
 				"@natlibfi/sru-client": "^7.0.1",
@@ -769,18 +769,18 @@
 			}
 		},
 		"node_modules/@natlibfi/issn-verify": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@natlibfi/issn-verify/-/issn-verify-2.0.2.tgz",
-			"integrity": "sha512-2/HfVM6FdhE3MbsH1M+X3PQ24emnAjf5U4xQexMmZfdPNwOCLxTI2KZBRiJmzWllPXSTcPy/b2mrNtBZBU+YIw==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/@natlibfi/issn-verify/-/issn-verify-2.0.3.tgz",
+			"integrity": "sha512-FsGS5vbLJsdrY24V/V4lDEbjbd7pkwDSpQn/e/faWuFGU0NLMZQJQC77VtWwMi8umf6YhcI+6iCVoM6AJx4aCQ==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=22"
 			}
 		},
 		"node_modules/@natlibfi/marc-record": {
-			"version": "10.0.1",
-			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record/-/marc-record-10.0.1.tgz",
-			"integrity": "sha512-ENEMr0sMyM/LUViZ/+/SKQq/u9gju8GBKY4Rx+NsQ1JhV69F0/YbURropawG6eZHZJx0IlO7ncYZPJ6DfqWFHQ==",
+			"version": "10.0.2",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record/-/marc-record-10.0.2.tgz",
+			"integrity": "sha512-4w+YskqHX6IgHXJK6cy7RYJjamuMh/mrBEMLlsQVNJLUU7iv+0RsMBJdBYdyap5krBGVYYKGJwNiJkQy9V4JDA==",
 			"license": "MIT",
 			"dependencies": {
 				"debug": "^4.4.3",
@@ -791,13 +791,13 @@
 			}
 		},
 		"node_modules/@natlibfi/marc-record-serializers": {
-			"version": "11.0.2",
-			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-serializers/-/marc-record-serializers-11.0.2.tgz",
-			"integrity": "sha512-kic65Waxmj7N1XZsSM90/5X06TrVcGWZWU9ISEJC9ABHW9EAF70qcaZWnSRBk94MlXcx/RMkHZCVNPCQ/gLfZg==",
+			"version": "11.0.3",
+			"resolved": "https://registry.npmjs.org/@natlibfi/marc-record-serializers/-/marc-record-serializers-11.0.3.tgz",
+			"integrity": "sha512-Gde+TxGcSyj206e3X9ySMmE4mHfm+fEHXUOZ8rKXWzp/Ci/l9AVuLnY0rO0hxf9JZNWxAs4eJP42qgCBqCi7+w==",
 			"license": "MIT",
 			"dependencies": {
-				"@natlibfi/marc-record": "^10.0.1",
-				"@xmldom/xmldom": "^0.9.9",
+				"@natlibfi/marc-record": "^10.0.2",
+				"@xmldom/xmldom": "^0.9.10",
 				"stream-json": "^1.9.1",
 				"xml2js": "^0.6.2",
 				"yargs": "^18.0.0"
@@ -1043,9 +1043,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/estree": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+			"version": "1.0.9",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+			"integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -1208,9 +1208,9 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-			"integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+			"version": "5.0.6",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+			"integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1871,9 +1871,9 @@
 			}
 		},
 		"node_modules/get-east-asian-width": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
-			"integrity": "sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==",
+			"version": "1.6.0",
+			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+			"integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
@@ -2348,9 +2348,9 @@
 			"license": "MIT"
 		},
 		"node_modules/nock": {
-			"version": "14.0.14",
-			"resolved": "https://registry.npmjs.org/nock/-/nock-14.0.14.tgz",
-			"integrity": "sha512-PKk7tex0O3RRXUZC5XDKJ9yM3rYRPS13myduT85VIIYDBnib42Fpxoe6KxRSzqB4iL2NDxkcJ2yiskZ18hGLEQ==",
+			"version": "14.0.15",
+			"resolved": "https://registry.npmjs.org/nock/-/nock-14.0.15.tgz",
+			"integrity": "sha512-S0a47C9pLvcYx/Ugf0H30BVBEcUgMMBDk9VJIDlJ8XGrfH2QDUD4Tgdp45qDIiHttokBG+IbsOtsvIjGR/j3bg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
 		"dev:debug": "cross-env LOG_LEVEL=debug DEBUG=@natlibfi/* NODE_ENV=test npm run watch:test"
 	},
 	"dependencies": {
-		"@natlibfi/marc-record": "^10.0.1",
-		"@natlibfi/marc-record-serializers": "^11.0.2",
+		"@natlibfi/marc-record": "^10.0.2",
+		"@natlibfi/marc-record-serializers": "^11.0.3",
 		"@natlibfi/marc-record-validators-melinda": "^12.0.15",
 		"@natlibfi/melinda-commons": "^14.0.2",
 		"@natlibfi/sru-client": "^7.0.1",

--- a/src/cli.js
+++ b/src/cli.js
@@ -89,7 +89,7 @@ async function cli() {
         matchDetection.features.bib.hostComponent(),
         matchDetection.features.bib.isbn(),
         matchDetection.features.bib.issn(),
-        matchDetection.features.bib.sid(),
+        // matchDetection.features.bib.sid(),
         matchDetection.features.bib.otherStandardIdentifier(),
         // Let's not use the same title matchDetection here
         //matchDetection.features.bib.title(),
@@ -126,7 +126,7 @@ async function cli() {
         matchDetection.features.bib.hostComponent(),
         matchDetection.features.bib.isbn(),
         matchDetection.features.bib.issn(),
-        matchDetection.features.bib.sid(),
+        // matchDetection.features.bib.sid(),
         matchDetection.features.bib.otherStandardIdentifier(),
         matchDetection.features.bib.title(),
         matchDetection.features.bib.authors(),

--- a/src/cli.js
+++ b/src/cli.js
@@ -89,6 +89,7 @@ async function cli() {
         matchDetection.features.bib.hostComponent(),
         matchDetection.features.bib.isbn(),
         matchDetection.features.bib.issn(),
+        matchDetection.features.bib.sid(),
         matchDetection.features.bib.otherStandardIdentifier(),
         // Let's not use the same title matchDetection here
         //matchDetection.features.bib.title(),
@@ -125,6 +126,7 @@ async function cli() {
         matchDetection.features.bib.hostComponent(),
         matchDetection.features.bib.isbn(),
         matchDetection.features.bib.issn(),
+        matchDetection.features.bib.sid(),
         matchDetection.features.bib.otherStandardIdentifier(),
         matchDetection.features.bib.title(),
         matchDetection.features.bib.authors(),
@@ -138,6 +140,7 @@ async function cli() {
 
     if (['YSO']) {
       return [
+        // matchDetection.features.bib.sid(), // SIDs might be relevant on the auth side as well?
         matchDetection.features.auth.yso()
       ];
     }

--- a/src/match-detection/features/bib/index.js
+++ b/src/match-detection/features/bib/index.js
@@ -2,6 +2,7 @@
 export {default as hostComponent} from './host-component.js';
 export {default as isbn} from './isbn.js';
 export {default as issn} from './issn.js';
+export {default as sid} from './sid.js';
 export {default as otherStandardIdentifier} from './other-standard-identifier.js';
 export {default as title} from './title.js';
 export {default as authors} from './authors.js';

--- a/src/match-detection/features/bib/isbn.js
+++ b/src/match-detection/features/bib/isbn.js
@@ -9,12 +9,24 @@ const debugData = debug.extend('data');
 
 const MAX_SCORE = 0.75;
 
+const setRegexp = /(?:complete set|hela verket|helhet|koko kartasto|koko paketti|koko sarja|koko setti|koko teoksen isbn|koko teos|kokonaisuus|^set\b|\bset$|\bsetti\b|vol.*set)/ui;
+
 export default () => ({
   name: 'ISBN',
   extract: ({record/*, recordExternal*/}) => {
     //const label = recordExternal && recordExternal.label ? recordExternal.label : 'record';
 
-    return record.get('020').filter(f => f.subfields?.some(sf => ['a', 'z'].includes(sf.code) && sf.value));
+    const all = record.get('020').filter(f => f.subfields?.some(sf => ['a', 'z'].includes(sf.code) && sf.value));
+    const sets = all.filter(f => isSetIsbnField(f));
+    const noSets = all.filter(f => !isSetIsbnField(f));
+    if (sets.length > 0 && noSets.length > 0) {
+      return noSets;
+    }
+    return all;
+
+    function isSetIsbnField(field) {
+      return field.subfields.some(sf => sf.code === 'q' && setRegexp.test(sf.value));
+    }
   },
   compare: (aa, bb) => {
     debugData(`Comparing ISBN sets ${JSON.stringify(aa)} and ${JSON.stringify(bb)}`);

--- a/src/match-detection/features/bib/sid.js
+++ b/src/match-detection/features/bib/sid.js
@@ -1,0 +1,48 @@
+// SID checker: if organization ($c) is same, also id ($b) should always be same.
+// Return values: 0 (no problems) and -1.0 (conflict, press panic button)
+// Raison d'être: SID check is also done in match validator, but as I (nvolk) somehow managed to bypass it with Saamelaisbibliografia imports.
+// Also the earlier we filter these weeds, the better.
+// Re-implementation is simpler (and lighter) than importing and using match validator's implementation (sigh!).
+// But of course, there should be but one implementation...
+
+import { fieldToString } from '@natlibfi/marc-record-validators-melinda';
+import createDebugLogger from 'debug';
+
+const debug = createDebugLogger(`@natlibfi/melinda-record-matching:match-detection:features:standard-identifiers:SID`);
+const debugData = debug.extend('data');
+
+
+export default () => ({
+  name: 'SID',
+  extract: ({record/*, recordExternal*/}) => {
+    const SIDs = record.get('SID');
+    return SIDs;
+  },
+  compare: (aa, bb) => {
+    debugData(`Comparing SID sets ${JSON.stringify(aa)} and ${JSON.stringify(bb)}`);
+    if (aa.length === 0 || bb.length === 0) {
+      return 0;
+    }
+
+    if (aa.some(field1 => bb.some(field2 => hasConflict(field1, field2)))) {
+      return -1.0; // Big bad number that prevents match
+    }
+    return 0;
+
+    function hasConflict(f1, f2) {
+      // Check organisation:
+      const b1 = f1.subfields.find(sf => sf.code === 'b');
+      const b2 = f2.subfields.find(sf => sf.code === 'b');
+      //debug(`SID\$b: ${b1.value} VS ${b2.value}`);
+      if (!b1 || !b1.value || !b2 || !b2.value || b1.value !== b2.value) { // Different orgs can not have a conflict
+        return false;
+      }
+      // Check local ID:
+      const c1 = f1.subfields.find(sf => sf.code === 'c');
+      const c2 = f2.subfields.find(sf => sf.code === 'c');
+      const result = c1 && c2 && c1.value && c2.value && c1.value !== c2.value;
+      //debug(`SID\$c: ${c1.value} VS ${c2.value} => ${result}`);
+      return result;
+    }
+  }
+});

--- a/test-fixtures/match-detection/features/bib/isbn/59/metadata.json
+++ b/test-fixtures/match-detection/features/bib/isbn/59/metadata.json
@@ -1,0 +1,39 @@
+{
+  "description": "Set ISBNs are not dropped as there are no other ISBNs",
+  "feature": "isbn",
+  "type": "extract",
+  "expectedFeatures": [
+    { "tag": "020", "ind1": " ", "ind2": " ",
+      "subfields": [
+        { "code": "a", "value": "952-90-8082-4" },
+        { "code": "q", "value": "helhet" }
+      ]
+    },
+    { "tag": "020", "ind1": " ", "ind2": " ",
+      "subfields": [
+        { "code": "a", "value": "952-62-2477-91" },
+        { "code": "q", "value": "complete set" }
+      ]
+    }
+  ],
+  "inputRecord": {
+    "leader": "02518cam a2200745zi 4500",
+    "fields": [
+      { "tag": "001", "value": "000019643" },
+      { "tag": "020", "ind1": " ", "ind2": " ",
+        "subfields": [
+          { "code": "a", "value": "952-90-8082-4" },
+          { "code": "q", "value": "helhet" }
+        ]
+      },
+      { "tag": "020", "ind1": " ", "ind2": " ",
+        "subfields": [
+          { "code": "a", "value": "952-62-2477-91" },
+          { "code": "q", "value": "complete set" }
+        ]
+      }
+    ]
+  },
+  "skip": false,
+  "only": false
+}

--- a/test-fixtures/match-detection/features/bib/isbn/60/metadata.json
+++ b/test-fixtures/match-detection/features/bib/isbn/60/metadata.json
@@ -1,0 +1,32 @@
+{
+  "description": "Set ISBN (here 'helhet') gets dropped",
+  "feature": "isbn",
+  "type": "extract",
+  "expectedFeatures": [
+    { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [
+        { "code": "a", "value": "952-62-2477-91" },
+        { "code": "q", "value": "PDF" }
+      ]
+    }
+  ],
+  "inputRecord": {
+    "leader": "02518cam a2200745zi 4500",
+    "fields": [
+      { "tag": "001", "value": "000019643" },
+      { "tag": "020", "ind1": " ", "ind2": " ",
+        "subfields": [
+          { "code": "a", "value": "952-90-8082-4" },
+          { "code": "q", "value": "helhet" }
+        ]
+      },
+      { "tag": "020", "ind1": " ", "ind2": " ",
+        "subfields": [
+          { "code": "a", "value": "952-62-2477-91" },
+          { "code": "q", "value": "PDF" }
+        ]
+      }
+    ]
+  },
+  "skip": false,
+  "only": false
+}

--- a/test-fixtures/match-detection/features/bib/sid/01/metadata.json
+++ b/test-fixtures/match-detection/features/bib/sid/01/metadata.json
@@ -1,0 +1,24 @@
+{
+  "description": "Matching identical SIDs (plus some noise) -> no penalty",
+  "feature": "sid",
+  "type": "compare",
+  "expectedPoints": 0.0,
+  "featuresA": [
+    { "tag": "SID", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "c", "value": "123" },
+      { "code": "b", "value": "FOO"}
+    ]}
+  ],
+  "featuresB": [
+    { "tag": "SID", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "c", "value": "234" },
+      { "code": "b", "value": "BAR"}
+    ]},
+    { "tag": "SID", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "c", "value": "123" },
+      { "code": "b", "value": "FOO"}
+    ]}
+  ],
+  "skip": false,
+  "only": false
+}

--- a/test-fixtures/match-detection/features/bib/sid/02/metadata.json
+++ b/test-fixtures/match-detection/features/bib/sid/02/metadata.json
@@ -1,0 +1,20 @@
+{
+  "description": "Non-matchings SIDs -> no penalty",
+  "feature": "sid",
+  "type": "compare",
+  "expectedPoints": 0.0,
+  "featuresA": [
+    { "tag": "SID", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "c", "value": "123" },
+      { "code": "b", "value": "FOO"}
+    ]}
+  ],
+  "featuresB": [
+    { "tag": "SID", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "c", "value": "123" },
+      { "code": "b", "value": "BAR"}
+    ]}
+  ],
+  "skip": false,
+  "only": false
+}

--- a/test-fixtures/match-detection/features/bib/sid/03/metadata.json
+++ b/test-fixtures/match-detection/features/bib/sid/03/metadata.json
@@ -1,0 +1,24 @@
+{
+  "description": "Matching mismatching SIDs (and noise) -> penalty",
+  "feature": "sid",
+  "type": "compare",
+  "expectedPoints": -1.0,
+  "featuresA": [
+    { "tag": "SID", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "c", "value": "123" },
+      { "code": "b", "value": "FOO"}
+    ]}
+  ],
+  "featuresB": [
+    { "tag": "SID", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "c", "value": "234" },
+      { "code": "b", "value": "BAR"}
+    ]},
+    { "tag": "SID", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "c", "value": "234" },
+      { "code": "b", "value": "FOO"}
+    ]}
+  ],
+  "skip": false,
+  "only": false
+}

--- a/test-fixtures/match-detection/features/bib/sid/51/metadata.json
+++ b/test-fixtures/match-detection/features/bib/sid/51/metadata.json
@@ -1,0 +1,71 @@
+{
+  "description": "Should extract SID field(s)",
+  "feature": "sid",
+  "type": "extract",
+  "expectedFeatures": [
+    { "tag": "SID", "ind1": " ", "ind2": " ", "subfields": [
+      { "code": "c", "value": "234" },
+      { "code": "b", "value": "BAR"}
+    ]}
+  ],
+  "inputRecord": {
+    "leader": "02518cam a2200745zi 4500",
+    "fields": [
+      {
+        "tag": "001",
+        "value": "000019643"
+      },
+      { "tag": "SID", "ind1": " ", "ind2": " ", "subfields": [
+        { "code": "c", "value": "234" },
+        { "code": "b", "value": "BAR"}
+      ]},
+      {
+        "tag": "020",
+        "ind1": " ",
+        "ind2": " ",
+        "subfields": [
+          {
+            "code": "a",
+            "value": "978-951-31-4836-2"
+          },
+          {
+            "code": "q",
+            "value": "PDF"
+          }
+        ]
+      },
+      {
+        "tag": "020",
+        "ind1": " ",
+        "ind2": " ",
+        "subfields": [
+          {
+            "code": "a",
+            "value": "978-952-62-2477-0"
+          },
+          {
+            "code": "q",
+            "value": "PDF"
+          }
+        ]
+      },
+      {
+        "tag": "020",
+        "ind1": " ",
+        "ind2": " ",
+        "subfields": [
+          {
+            "code": "a",
+            "value": "9789526224770"
+          },
+          {
+            "code": "q",
+            "value": "PDF"
+          }
+        ]
+      }
+    ]
+  },
+  "skip": false,
+  "only": false
+}

--- a/test-fixtures/match-detection/index/01/metadata.json
+++ b/test-fixtures/match-detection/index/01/metadata.json
@@ -5,7 +5,8 @@
       "type": "bib",
       "features": [
         "title",
-        "isbn"
+        "isbn",
+        "sid"
       ]
     }
   },

--- a/test-fixtures/match-detection/index/01/recordA.json
+++ b/test-fixtures/match-detection/index/01/recordA.json
@@ -11,6 +11,11 @@
         { "code": "a", "value": "foo." },
         { "code": "b", "value": "bar" }
       ]
+    },
+    { "tag": "SID", "ind1": " ", "ind2": " ", "subfields": [
+        { "code": "c", "value": "667" },
+        { "code": "b", "value": "ALAKERTA" }
+      ]
     }
   ]
 }

--- a/test-fixtures/match-detection/index/01/recordA.json
+++ b/test-fixtures/match-detection/index/01/recordA.json
@@ -1,38 +1,15 @@
 {
   "leader": "02518cam a2200745zi 4500",
   "fields": [
-    {
-      "tag": "001",
-      "value": "000019643"
-    },
-    {
-      "tag": "020",
-      "ind1": " ",
-      "ind2": " ",
-      "subfields": [
-        {
-          "code": "a",
-          "value": "978-952-62-2477-0"
-        },
-        {
-          "code": "q",
-          "value": "PDF"
-        }
+    { "tag": "001", "value": "000019643" },
+    { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [
+        { "code": "a", "value": "978-952-62-2477-0" },
+        { "code": "q", "value": "PDF" }
       ]
     },
-    {
-      "tag": "245",
-      "ind1": "1",
-      "ind2": " ",
-      "subfields": [
-        {
-          "code": "a",
-          "value": "foo."
-        },
-        {
-          "code": "b",
-          "value": "bar"
-        }
+    { "tag": "245", "ind1": "1", "ind2": " ", "subfields": [
+        { "code": "a", "value": "foo." },
+        { "code": "b", "value": "bar" }
       ]
     }
   ]

--- a/test-fixtures/match-detection/index/01/recordB.json
+++ b/test-fixtures/match-detection/index/01/recordB.json
@@ -11,6 +11,11 @@
         { "code": "a", "value": "foo." },
         { "code": "b", "value": "bar" }
       ]
+    },
+    { "tag": "SID", "ind1": " ", "ind2": " ", "subfields": [
+        { "code": "c", "value": "667" },
+        { "code": "b", "value": "ALAKERTA" }
+      ]
     }
   ]
 }

--- a/test-fixtures/match-detection/index/01/recordB.json
+++ b/test-fixtures/match-detection/index/01/recordB.json
@@ -1,38 +1,15 @@
 {
   "leader": "02518cam a2200745zi 4500",
   "fields": [
-    {
-      "tag": "001",
-      "value": "000019644"
-    },
-    {
-      "tag": "020",
-      "ind1": " ",
-      "ind2": " ",
-      "subfields": [
-        {
-          "code": "a",
-          "value": "978-952-62-2477-0"
-        },
-        {
-          "code": "q",
-          "value": "PDF"
-        }
+    { "tag": "001", "value": "000019644" },
+    { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [
+        { "code": "a", "value": "978-952-62-2477-0" },
+        { "code": "q", "value": "PDF" }
       ]
     },
-    {
-      "tag": "245",
-      "ind1": "1",
-      "ind2": " ",
-      "subfields": [
-        {
-          "code": "a",
-          "value": "foo."
-        },
-        {
-          "code": "b",
-          "value": "bar"
-        }
+    { "tag": "245", "ind1": "1", "ind2": " ", "subfields": [
+        { "code": "a", "value": "foo." },
+        { "code": "b", "value": "bar" }
       ]
     }
   ]

--- a/test-fixtures/match-detection/index/23/metadata.json
+++ b/test-fixtures/match-detection/index/23/metadata.json
@@ -1,0 +1,17 @@
+{
+  "description": "Should fail to detect a match due to SID issues (otherwise same as test 01)",
+  "options": {
+    "strategy": {
+      "type": "bib",
+      "features": [
+        "title",
+        "isbn",
+        "sid"
+      ]
+    }
+  },
+  "expectedResults": {
+    "match": false,
+    "probability": 0.0
+  }
+}

--- a/test-fixtures/match-detection/index/23/recordA.json
+++ b/test-fixtures/match-detection/index/23/recordA.json
@@ -1,0 +1,21 @@
+{
+  "leader": "02518cam a2200745zi 4500",
+  "fields": [
+    { "tag": "001", "value": "000019643" },
+    { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [
+        { "code": "a", "value": "978-952-62-2477-0" },
+        { "code": "q", "value": "PDF" }
+      ]
+    },
+    { "tag": "245", "ind1": "1", "ind2": " ", "subfields": [
+        { "code": "a", "value": "foo." },
+        { "code": "b", "value": "bar" }
+      ]
+    },
+    { "tag": "SID", "ind1": " ", "ind2": " ", "subfields": [
+        { "code": "c", "value": "666" },
+        { "code": "b", "value": "ALAKERTA" }
+      ]
+    }
+  ]
+}

--- a/test-fixtures/match-detection/index/23/recordB.json
+++ b/test-fixtures/match-detection/index/23/recordB.json
@@ -1,0 +1,21 @@
+{
+  "leader": "02518cam a2200745zi 4500",
+  "fields": [
+    { "tag": "001", "value": "000019644" },
+    { "tag": "020", "ind1": " ", "ind2": " ", "subfields": [
+        { "code": "a", "value": "978-952-62-2477-0" },
+        { "code": "q", "value": "PDF" }
+      ]
+    },
+    { "tag": "245", "ind1": "1", "ind2": " ", "subfields": [
+        { "code": "a", "value": "foo." },
+        { "code": "b", "value": "bar" }
+      ]
+    },
+    { "tag": "SID", "ind1": " ", "ind2": " ", "subfields": [
+        { "code": "c", "value": "667" },
+        { "code": "b", "value": "ALAKERTA" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
- isbn-tarkistus: kokonaisuus pois, jos tietueessa on tavis-isbniäkin (MET-803 ja MET-804)

- SID-tarkistin tännekin (implementoitu jo match-validatorissa, mutta onnistuin tekemään Saamelaisbibliografian kanssa vientejä ton ohi jollain asetuksilla, ja muuten parempi torpata noi ennemmin kuin myöhemmin)