### PR TITLE
Soitonopas et al, MELKEHITYS-3499

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
 				"@natlibfi/melinda-commons": "^14.0.2",
 				"@natlibfi/sru-client": "^7.0.1",
 				"debug": "^4.4.3",
-				"isbn3": "^2.0.7",
+				"isbn3": "^2.0.8",
 				"moment": "^2.30.1",
 				"natural": "^8.1.1",
 				"uuid": "^14.0.0",
@@ -30,7 +30,7 @@
 				"@natlibfi/fixura": "^4.0.1",
 				"cross-env": "^10.1.0",
 				"esbuild": "^0.28.0",
-				"eslint": "^10.4.0"
+				"eslint": "^10.4.1"
 			},
 			"engines": {
 				"node": ">=22"
@@ -611,9 +611,9 @@
 			}
 		},
 		"node_modules/@eslint/plugin-kit": {
-			"version": "0.7.1",
-			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.1.tgz",
-			"integrity": "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==",
+			"version": "0.7.2",
+			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+			"integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -1597,9 +1597,9 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "10.4.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.0.tgz",
-			"integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
+			"version": "10.4.1",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.1.tgz",
+			"integrity": "sha512-AyIKhnOBuOAdueD7RB3xB+YeAWScb9jHsJBgH2Hcde8InP5JYhqrRR6iTMHyTEwgENK54Cp44e4v8BwNhsuHuw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1608,7 +1608,7 @@
 				"@eslint/config-array": "^0.23.5",
 				"@eslint/config-helpers": "^0.6.0",
 				"@eslint/core": "^1.2.1",
-				"@eslint/plugin-kit": "^0.7.1",
+				"@eslint/plugin-kit": "^0.7.2",
 				"@humanfs/node": "^0.16.6",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@humanwhocodes/retry": "^0.4.2",
@@ -2017,9 +2017,9 @@
 			}
 		},
 		"node_modules/isbn3": {
-			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/isbn3/-/isbn3-2.0.7.tgz",
-			"integrity": "sha512-FYsoxXRHwj7GGr9xVp4UigwMWJFMzCYbDxWAb17/BG7d3Ml7TnzWxIyZhNtLvD1NVrUrzKF/MT9xogVFfd+jAQ==",
+			"version": "2.0.8",
+			"resolved": "https://registry.npmjs.org/isbn3/-/isbn3-2.0.8.tgz",
+			"integrity": "sha512-wDzOEM2Tox7nIOCqH7yHIhQs+bltttaGqMTk7J72VIhI9w6nLsFnHMrUtidQJR/WvZfg+qXeF2A9WFfs2nxYCg==",
 			"license": "MIT",
 			"bin": {
 				"isbn": "bin/isbn",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
 		"@natlibfi/melinda-commons": "^14.0.2",
 		"@natlibfi/sru-client": "^7.0.1",
 		"debug": "^4.4.3",
-		"isbn3": "^2.0.7",
+		"isbn3": "^2.0.8",
 		"moment": "^2.30.1",
 		"natural": "^8.1.1",
 		"uuid": "^14.0.0",
@@ -57,7 +57,7 @@
 		"@natlibfi/fixura": "^4.0.1",
 		"cross-env": "^10.1.0",
 		"esbuild": "^0.28.0",
-		"eslint": "^10.4.0"
+		"eslint": "^10.4.1"
 	},
 	"overrides": {
 		"uuid": "^14.0.0"

--- a/src/match-detection/features/bib/language.js
+++ b/src/match-detection/features/bib/language.js
@@ -129,12 +129,6 @@ export default () => ({
       return -0.1;
     }
 
-
-
-    function containsNoData(languageCode) {
-      return ['   ', '|||', 'und'].includes(languageCode);
-    }
-
     function compareLanguageCodeLists(a, b) {
       if (a.length === 0 || b.length === 0 || a.every(val => containsNoData(val)) || b.every(val => containsNoData(val))) {
         debugData(`No language to compare`);
@@ -170,36 +164,50 @@ export default () => ({
         return 0;
       }
 
-
-
       // Damage control:
-      const sharedValues = getSharedValues(a, b).filter(val => !containsNoData(val));
+      const sharedValues = getSharedValues(a, b); // NB! excludes meaningless values
 
       if (sharedValues.length < 1) {
-        debug(`Both have languages, but none of these match.`); // includes 'mul' vs a single language code
+        debug(`Both have languages, but none of these match.`);
         return -1.0;
       }
 
-      const {matchingValues, possibleMatchValues, maxValues} = getMatchCounts(a, b);
+      const aOnly = getUniqueInFirst(a, b); // NB! excludes meaningless values
+      const bOnly = getUniqueInFirst(b, a);
 
-      debug(`Both have languages, ${matchingValues}/${possibleMatchValues} valid languages match.`);
-      // ignore non-matches if there is mismatching amount of values
-      debug(`Possible matches: ${possibleMatchValues}/${maxValues}`);
-      // we give some kind of penalty for mismatching amount of values instead of simple divide?
-      const missingCount = maxValues - possibleMatchValues;
-      const misMatchCount = possibleMatchValues - matchingValues;
-      debug(`\t missing: ${missingCount}`);
-      debug(`\t mismatches: ${misMatchCount}`);
+      debug(`A only: ${aOnly.join(', ')}`);
+      debug(`B only: ${bOnly.join(', ')}`);
 
-      const penaltyForMissing = 0.02 * (maxValues - possibleMatchValues);
-      const penaltyForMisMatch = 0.05 * (possibleMatchValues - matchingValues);
-      debug(`\t points: penaltyForMissing: ${penaltyForMissing}`);
-      debug(`\t points: penaltyForMisMatch: ${penaltyForMisMatch}`);
+      return calculatePenalty();
 
-      const points = Number(Number(0.1 - penaltyForMisMatch - penaltyForMissing).toFixed(2));
-      debug(`Total points: ${points}`);
-
-      return points;
+      function calculatePenalty() {
+        const basePenalty = calculatePenalty2() / sharedValues.length;
+        if (basePenalty < -1.0) {
+          return -1.0;
+        }
+        return basePenalty;
+      }
+      
+      function calculatePenalty2() {
+        const n = aOnly.length + bOnly.length;
+        // It's reasonably ok for one to have more languages than the other (max penalty -0.3 for that):
+        if (aOnly.length === 0 || bOnly.length === 0) {
+          if (n > 3) {
+            return -0.3;
+          }
+          return 0.1 - (n * 0.1);
+        }
+        // Possible typo (should we calculate levenshtein distance for the value?):
+        if (aOnly.length === 1 && bOnly.length === 1) {
+          return -0.1; // Not too big a penalty
+        }
+        debug(` ${n} differences altogether`);
+        // However, it's worse to have different languages on both sides
+        if (n > 3) {
+          return -1.0;
+        }
+        return n * -0.2;
+      }
     }
   }
 
@@ -282,5 +290,13 @@ function getFieldsLanguageCodes(field) {
 }
 
 function getSharedValues(list1, list2) {
-  return list1.filter(val => list2.includes(val));
+  return list1.filter(val => list2.includes(val) && !containsNoData(val));
+}
+
+function getUniqueInFirst(list1, list2){
+  return list1.filter(val => !list2.includes(val) && !containsNoData(val));
+}
+
+function containsNoData(languageCode) {
+  return ['   ', '|||', 'und'].includes(languageCode);
 }

--- a/src/match-detection/features/bib/record-type.js
+++ b/src/match-detection/features/bib/record-type.js
@@ -1,10 +1,39 @@
-
-// we could handle the case of books/notes
-// Recordtype: LDR/06 - Type of Record
-// Note: currently matchValidator fails all mismatching recordTypes, so this won't actually do much
+// RecordType
+//
+// Array structure:
+// 0: record type
+// 1: is soitonopas; The English translation for soitionopas is both terrible and unused in Melinda, that I'm not using it ("musical instrument methods")
 
 export default () => ({
   name: 'Record type',
-  extract: ({record}) => record.leader[6] ? [record.leader[6]] : [],
-  compare: (a, b) => a[0] === b[0] ? 0.1 : -0.5
+  extract: ({record}) => {
+    const recordType = record.leader[6] || null;
+    const soitonopas = isSoitonopas();
+
+    return [recordType, soitonopas];
+
+    function isSoitonopas() {
+      if (recordType === 'c') {
+        const f300 = record.get('300');
+        if (f300.some(f => f.subfields?.some(sf => sf.code === 'a' && sf.value.match(/(?:instrumentskol|soitonopas)/ui)))) {
+          return true;       
+        }
+      }
+      return false;
+    }
+  },
+  compare: (a, b) => {
+     if (a[0] === b[0]) {
+      return 0.1;
+    }
+    // Soitonopas vs text/book: no bonus, no penalty
+    if (a[0] === 'a' && b[1]) {
+      return 0.0;
+    }
+    if (b[0] === 'a' && a[1]) {
+      return 0.0;
+    }
+    // Bad:
+    return  -0.5
+  }
 });

--- a/src/match-detection/features/bib/title.js
+++ b/src/match-detection/features/bib/title.js
@@ -28,6 +28,11 @@ export default ({threshold = 0.9} = {}) => ({
       return title
         // decompose unicode diacritics
         .normalize('NFD')
+        .replace(/\b(?:ett|I|one|uno|yksi)\b/ui, '1')
+        .replace(/\b(?:dos|kaksi|II|två|two|zwei)\b/ui, '2')
+        .replace(/\b(?:drei|III|kolme|three|tre|tres)\b/ui, '3')
+        .replace(/\b(?:four|fyra|IV|neljä|quat+ro|vier)\b/ui, '4')
+        .replace(/\b(?:five|fünf|fyra|viisi|V)\b/ui, '5')
         // strip non-letters/numbers
         // - note: combined with decomposing unicode diacritics this normalizes both 'saa' and 'sää' as 'saa'
         // - we could precompose the Finnish letters back to avoid this
@@ -48,12 +53,12 @@ export default ({threshold = 0.9} = {}) => ({
       const aFull = toFullTitle(a);
       const bFull = toFullTitle(b);
 
-      debug(`COMPARE:\n  '${aFull}' vs  \n  '${bFull}`);
+      debug(`COMPARE:\n  '${aFull}' vs  \n  '${bFull}'`);
 
       if (isEmpty(aa) || isEmpty(ba)) {
         return -1.0;
       }
-      // F245$n information is critical; it can not mismatch at all:
+      // F245$n information is critical; it can not mismatch at all (however, we should heavily normalize three->3, II->2 etc):
       if (an.length && bn.length && an !== bn) { // If these exists, they must be the same (we might convert Roman numbers to Arabic numbers though)
         return -1.0;
       }
@@ -61,6 +66,21 @@ export default ({threshold = 0.9} = {}) => ({
       if (ab && ab !== '' && ab === bb) { // Remove $b from equation (MELKEHITYS-3494)
         debug(`Ignore \$b ${ab}`);
         return compare2([aa, '', an, ap], [ba, '', bn, bp]);
+      }
+      if (an && an !== '' && an === bn) { // Remove $n from equation
+        debug(`Ignore \$n ${ab}`);
+        return compare2([aa, ab, '', ap], [ba, bb, '', bp]);
+      }
+      if (ap && ap !== '' && ap === bp) { // Remove $p from equation
+        debug(`Ignore \$p ${ap}`);
+        return compare2([aa, ab, an, ''], [ba, bb, bn, '']);
+      }
+      // There seems to be wobble between $b and $p
+      if (!isEmpty(ab) && ab === bp) {
+        return compare2([aa, '', an, ap], [ba, bb, bn, '']);
+      }
+      if (!isEmpty(ap) && ap === bv) {
+        return compare2([aa, ab, an, ''], [ba, '', bn, bp]);
       }
 
       const [distance, maxLength, correctness] = doLevenshtein(aFull, bFull);
@@ -75,32 +95,34 @@ export default ({threshold = 0.9} = {}) => ({
         return 0.4;
       }
 
-      if (an && bn) {
-        // There seems to be some wobble between $b and $p, for example:
-        if (ab && isEmpty(ap) && bp && isEmpty(bb)) {
-          const tmp = compare2([aa, ap, an, ab], [ba, bb, bn, bp]);
-          if (tmp >= 0.4) {
-            return 0.4;
-          }
+      // Subset removal (MELKEHITYS-3498-ish)
+      if (ab && bb) { // At this point ab and bb are never equal...
+        // If X is a subset of Y, then remove X and shorten Y (= remove the shared content)
+        if (ab.indexOf(bb) === 0) {
+          return compare2([aa, ab.substring(bb.length), an, ap], [ba, '', bn, bp]);
         }
-        if (ap && isEmpty(ab) && bb && isEmpty(bp)) {
-          const tmp = compare2([aa, ab, an, ap], [ba, bp, bn, bb]);
-          if (tmp >= 0.4) {
-            return 0.4;
-          }
+        if (bb.indexOf(ab) === 0) {
+          return compare2([aa, '', an, ap], [ba, bb.substring(ab.length), bn, bp]);
         }
       }
-
+  
       // Try the same without $p:
       if (localXor(ap, bp)) {
         const result = compare2([aa, ab, an, ''], [ba, bb, bn, '']);
         return result > 0.0 ? result * 0.8 : result;
       }
-
-      if (isEmpty(ap) && isEmpty(bp) && localXor(ab, bb)) {
-        // Try the same without $b ($p is not here)
-        const result = compare2([aa, '', an, ''], [ba, '', bn, '']);
-        return result > 0.0 ? result * 0.8 : result;
+    
+      if (aa === ba && an === bn) {
+        // No $n: Don't score $a vs $ab. Return 0, and let other match detectors decide
+        const candScore = 0.25;
+        if (ap === bp && localXor(ab, bb)) {
+          debug(`Handle omitted \$b using x ${candScore}`);
+          return candScore;
+        }
+        if (ab === bb && localXor(ap, bp)) {
+          debug(`Handle omitted \$p using x ${candScore}`);
+          return candScore;
+        }
       }
 
       return -0.5; // Not likely

--- a/src/match-detection/features/bib/title.js
+++ b/src/match-detection/features/bib/title.js
@@ -2,6 +2,7 @@ import createDebugLogger from 'debug';
 import naturalPkg from 'natural';
 const {LevenshteinDistance: leven} = naturalPkg;
 import {testStringOrNumber} from '../../../matching-utils.js';
+import { subfieldToString } from '@natlibfi/marc-record-validators-melinda/dist/utils.js';
 
 
 const debug = createDebugLogger('@natlibfi/melinda-record-matching:match-detection:features/bib/title');
@@ -36,56 +37,74 @@ export default ({threshold = 0.9} = {}) => ({
     }
 
   },
-  compare: (a, b) => {
-    const [aa, ab, an, ap] = a;
-    const [ba, bb, bn, bp] = b;
+  compare: (origA, origB) => {
+    return compare2(origA, origB);
 
-    if (isEmpty(aa) || isEmpty(ba)) {
-      return -1.0;
-    }
-    // F245$n information is critical; it can not mismatch at all:
-    if (an.length && bn.length && an !== bn) { // If these exists, they must be the same (we might convert Roman numbers to Arabic numbers though)
-      return -1.0;
-    }
+    function compare2(a, b) { // Added this wrapper function as I had issues with recursion
 
-    const aFull = toFullTitle(a);
-    const bFull = toFullTitle(b);
+      const [aa, ab, an, ap] = a;
+      const [ba, bb, bn, bp] = b;
 
-    const [distance, maxLength, correctness] = doLevenshtein(aFull, bFull);
+      const aFull = toFullTitle(a);
+      const bFull = toFullTitle(b);
 
-    debug(`'${aFull}' vs '${bFull}': Max length = ${maxLength}, distance = ${distance}, correctness = ${correctness}`);
+      debug(`COMPARE:\n  '${aFull}' vs  \n  '${bFull}`);
 
-    if (distance === 0) {
-      return 0.5;
-    }
-
-    if (correctness >= threshold) {
-      return 0.4;
-    }
-
-    if (an && bn) {
-      // There seems to be some wobble between $b and $p, for example:
-      if (ab && isEmpty(ap) && bp && isEmpty(bb)) {
-        return compare([aa, ap, an, ab], [ba, bb, bn, bp]);
+      if (isEmpty(aa) || isEmpty(ba)) {
+        return -1.0;
       }
-      if (ap && isEmpty(ab) && bb && isEmpty(bp)) {
-        return compare([aa, ab, an, ap], [ba, bp, bn, bb]);
+      // F245$n information is critical; it can not mismatch at all:
+      if (an.length && bn.length && an !== bn) { // If these exists, they must be the same (we might convert Roman numbers to Arabic numbers though)
+        return -1.0;
       }
-    }
 
-    // Try the same without $p:
-    if (localXor(ap, bp)) {
-      const result = compare([aa, ab, an, ''], [ba, bb, bn, '']);
-      return result > 0.0 ? result * 0.8 : result;
-    }
+      if (ab && ab !== '' && ab === bb) { // Remove $b from equation (MELKEHITYS-3494)
+        debug(`Ignore \$b ${ab}`);
+        return compare2([aa, '', an, ap], [ba, '', bn, bp]);
+      }
 
-    if (isEmpty(ap) && isEmpty(bp) && localXor(ab, bb)) {
-      // Try the same without $b ($p is not here)
-      const result = compare([aa, '', an, ''], [ba, '', bn, '']);
-      return result > 0.0 ? result * 0.8 : result;
-    }
+      const [distance, maxLength, correctness] = doLevenshtein(aFull, bFull);
 
-    return -0.5; // Not likely
+      debug(`'${aFull}' vs '${bFull}': Max length = ${maxLength}, distance = ${distance}, correctness = ${correctness}`);
+
+      if (distance === 0) {
+        return 0.5;
+      }
+
+      if (correctness >= threshold) {
+        return 0.4;
+      }
+
+      if (an && bn) {
+        // There seems to be some wobble between $b and $p, for example:
+        if (ab && isEmpty(ap) && bp && isEmpty(bb)) {
+          const tmp = compare2([aa, ap, an, ab], [ba, bb, bn, bp]);
+          if (tmp >= 0.4) {
+            return 0.4;
+          }
+        }
+        if (ap && isEmpty(ab) && bb && isEmpty(bp)) {
+          const tmp = compare2([aa, ab, an, ap], [ba, bp, bn, bb]);
+          if (tmp >= 0.4) {
+            return 0.4;
+          }
+        }
+      }
+
+      // Try the same without $p:
+      if (localXor(ap, bp)) {
+        const result = compare2([aa, ab, an, ''], [ba, bb, bn, '']);
+        return result > 0.0 ? result * 0.8 : result;
+      }
+
+      if (isEmpty(ap) && isEmpty(bp) && localXor(ab, bb)) {
+        // Try the same without $b ($p is not here)
+        const result = compare2([aa, '', an, ''], [ba, '', bn, '']);
+        return result > 0.0 ? result * 0.8 : result;
+      }
+
+      return -0.5; // Not likely
+    }
 
     function isEmpty(x) {
       return !x || x.length === 0;
@@ -108,7 +127,8 @@ export default ({threshold = 0.9} = {}) => ({
 
     function toFullTitle(arr) {
       const relevant = arr.filter(val => typeof val === 'string' && val.length);
-      return relevant.join(' ');
+      // No longer add space between subfields. Due to heavy normalization there are no spaces left in array elements either!
+      return relevant.join('');
     }
 
     function getMaxLength(str1, str2) {

--- a/src/match-detection/features/bib/title.js
+++ b/src/match-detection/features/bib/title.js
@@ -8,6 +8,7 @@ import { subfieldToString } from '@natlibfi/marc-record-validators-melinda/dist/
 const debug = createDebugLogger('@natlibfi/melinda-record-matching:match-detection:features/bib/title');
 const debugData = debug.extend('data');
 
+const TITLE_MAX = 0.5;
 export default ({threshold = 0.9} = {}) => ({
   name: 'Title',
   extract: ({record, recordExternal}) => {
@@ -28,16 +29,18 @@ export default ({threshold = 0.9} = {}) => ({
       return title
         // decompose unicode diacritics
         .normalize('NFD')
-        .replace(/\b(?:ett|I|one|uno|yksi)\b/ui, '1')
-        .replace(/\b(?:dos|kaksi|II|två|two|zwei)\b/ui, '2')
-        .replace(/\b(?:drei|III|kolme|three|tre|tres)\b/ui, '3')
-        .replace(/\b(?:four|fyra|IV|neljä|quat+ro|vier)\b/ui, '4')
-        .replace(/\b(?:five|fünf|fyra|viisi|V)\b/ui, '5')
+        .replace(/\b(?:ein|ett|I|one|uno|yksi)\b/uig, '1')
+        .replace(/\b(?:dos|kaksi|II|två|two|zwei)\b/uig, '2')
+        .replace(/\b(?:drei|III|kolme|three|tre|tres)\b/uig, '3')
+        .replace(/\b(?:four|fyra|IV|neljä|quat+ro|vier)\b/uig, '4')
+        .replace(/\b(?:five|fünf|fyra|viisi|V)\b/uig, '5')
+        .replace(/\b(?:kuusi|sechts|sex|six|VI)\b/uig, '6')
+        .replace(/\b(and|ja|och|und)\b/uig, '&')
         // strip non-letters/numbers
         // - note: combined with decomposing unicode diacritics this normalizes both 'saa' and 'sää' as 'saa'
         // - we could precompose the Finnish letters back to avoid this
         // - see validator normalize-utf8-diacritics for details
-        .replace(/[^\p{Letter}\p{Number}]/gu, '')
+        .replace(/[^\p{Letter}\p{Number}&]/gu, '')
         .toLowerCase();
     }
 
@@ -58,17 +61,18 @@ export default ({threshold = 0.9} = {}) => ({
       if (isEmpty(aa) || isEmpty(ba)) {
         return -1.0;
       }
-      // F245$n information is critical; it can not mismatch at all (however, we should heavily normalize three->3, II->2 etc):
-      if (an.length && bn.length && an !== bn) { // If these exists, they must be the same (we might convert Roman numbers to Arabic numbers though)
-        return -1.0;
+
+      if (aFull === bFull) {
+        return TITLE_MAX;
       }
+
 
       if (ab && ab !== '' && ab === bb) { // Remove $b from equation (MELKEHITYS-3494)
         debug(`Ignore \$b ${ab}`);
         return compare2([aa, '', an, ap], [ba, '', bn, bp]);
       }
       if (an && an !== '' && an === bn) { // Remove $n from equation
-        debug(`Ignore \$n ${ab}`);
+        debug(`Ignore \$n ${an}`);
         return compare2([aa, ab, '', ap], [ba, bb, '', bp]);
       }
       if (ap && ap !== '' && ap === bp) { // Remove $p from equation
@@ -79,20 +83,33 @@ export default ({threshold = 0.9} = {}) => ({
       if (!isEmpty(ab) && ab === bp) {
         return compare2([aa, '', an, ap], [ba, bb, bn, '']);
       }
-      if (!isEmpty(ap) && ap === bv) {
+      if (!isEmpty(ap) && ap === bp) {
         return compare2([aa, ab, an, ''], [ba, '', bn, bp]);
+      }
+
+      if (an && bn && an.match(/[0-9]/u)) {
+        debug(`NUMBER FOUND. Compare ${an} and ${bn}`);
+        const atmp = an.replace(/[^0-9]/ug, '');
+        const btmp = bn.replace(/[^0-9]/ug, '');
+        if (atmp === btmp) {
+          debug(`Ignore \$n '${an}' vs '${bn}'`);
+          return compare2([aa, ab, '', ap], [ba, bb, '', bp]);
+        }
+      }
+
+
+      // f245$n information is critical; it can not mismatch at all  (exceptions have already been handled above):
+      if (an && an !== bn) {
+        return -1.0;
       }
 
       const [distance, maxLength, correctness] = doLevenshtein(aFull, bFull);
 
       debug(`'${aFull}' vs '${bFull}': Max length = ${maxLength}, distance = ${distance}, correctness = ${correctness}`);
 
-      if (distance === 0) {
-        return 0.5;
-      }
 
       if (correctness >= threshold) {
-        return 0.4;
+        return TITLE_MAX * 0.8;
       }
 
       // Subset removal (MELKEHITYS-3498-ish)
@@ -114,7 +131,7 @@ export default ({threshold = 0.9} = {}) => ({
     
       if (aa === ba && an === bn) {
         // No $n: Don't score $a vs $ab. Return 0, and let other match detectors decide
-        const candScore = 0.25;
+        const candScore = TITLE_MAX/2;
         if (ap === bp && localXor(ab, bb)) {
           debug(`Handle omitted \$b using x ${candScore}`);
           return candScore;

--- a/test-fixtures/match-detection/features/bib/language/18/metadata.json
+++ b/test-fixtures/match-detection/features/bib/language/18/metadata.json
@@ -1,8 +1,8 @@
 {
-  "description": "Comparison should return minimal amount of points for partially matching languages (1 match, 1 mismatch)",
+  "description": "Comparison should return small penalty (1 match + 1 mismatch one both sides)",
   "feature": "language",
   "type": "compare",
-  "expectedPoints": 0.05,
+  "expectedPoints": -0.1,
   "featuresA": [[
       {"tag": "041", "ind1": " ", "ind2": " ", "subfields": [{"code": "a", "value": "eng"}, {"code": "a", "value": "swe"}]}
     ], "A"],

--- a/test-fixtures/match-detection/features/bib/language/22/metadata.json
+++ b/test-fixtures/match-detection/features/bib/language/22/metadata.json
@@ -1,16 +1,24 @@
 {
-  "description": "Comparison should return minimal amount of points for partially matching languages (1 missing)",
+  "description": "Fail totally since too many mismatches on both sides",
   "feature": "language",
   "type": "compare",
-  "expectedPoints": 0.08,
+  "expectedPoints": -1.0,
   "featuresA": [
     [
-      {"tag": "041", "ind1": " ", "ind2": " ", "subfields": [{"code": "a", "value": "rum"}]}
+      {"tag": "041", "ind1": " ", "ind2": " ", "subfields": [
+        {"code": "a", "value": "rum"},
+        {"code": "a", "value": "rus"},
+        {"code": "a", "value": "nor"},
+        {"code": "a", "value": "hrv"},
+        {"code": "a", "value": "yyz"},
+        {"code": "a", "value": "foo"},
+        {"code": "a", "value": "bar"}
+      ]}
     ],
     "A"],
   "featuresB": [
     [
-      {"tag": "041", "ind1": " ", "ind2": " ", "subfields": [{"code": "a", "value": "rum"}, {"code": "a", "value": "fin"}]}
+      {"tag": "041", "ind1": " ", "ind2": " ", "subfields": [{"code": "a", "value": "rum"}, {"code": "a", "value": "fin"}, {"code": "a", "value": "est"}]}
     ],
     "B"],
   "skip": false,

--- a/test-fixtures/match-detection/features/bib/language/25/metadata.json
+++ b/test-fixtures/match-detection/features/bib/language/25/metadata.json
@@ -1,0 +1,14 @@
+{
+  "description": "Comparison should return no points nor penalty (1 match + 1 additional on the other side)",
+  "feature": "language",
+  "type": "compare",
+  "expectedPoints": 0.0,
+  "featuresA": [[
+      {"tag": "041", "ind1": " ", "ind2": " ", "subfields": [{"code": "a", "value": "eng"}, {"code": "a", "value": "swe"}]}
+    ], "A"],
+  "featuresB": [[
+      {"tag": "041", "ind1": " ", "ind2": " ", "subfields": [{"code": "a", "value": "eng"}]}
+    ], "B"],
+  "skip": false,
+  "only": true
+}

--- a/test-fixtures/match-detection/features/bib/language/25/metadata.json
+++ b/test-fixtures/match-detection/features/bib/language/25/metadata.json
@@ -10,5 +10,5 @@
       {"tag": "041", "ind1": " ", "ind2": " ", "subfields": [{"code": "a", "value": "eng"}]}
     ], "B"],
   "skip": false,
-  "only": true
+  "only": false
 }

--- a/test-fixtures/match-detection/features/bib/language/26/metadata.json
+++ b/test-fixtures/match-detection/features/bib/language/26/metadata.json
@@ -1,0 +1,14 @@
+{
+  "description": "Test MELKEHITYYS-3501: meaningless values should not matter",
+  "feature": "language",
+  "type": "compare",
+  "expectedPoints": 0.0,
+  "featuresA": [[
+      {"tag": "041", "ind1": " ", "ind2": " ", "subfields": [{"code": "a", "value": "zxx"}, {"code": "d", "value": "und"}]}
+    ], "A"],
+  "featuresB": [[
+      {"tag": "041", "ind1": " ", "ind2": " ", "subfields": [{"code": "d", "value": "und"}]}
+    ], "B"],
+  "skip": false,
+  "only": false
+}

--- a/test-fixtures/match-detection/features/bib/record-type/01/metadata.json
+++ b/test-fixtures/match-detection/features/bib/record-type/01/metadata.json
@@ -2,14 +2,14 @@
   "description": "Should extract record type",
   "feature": "recordType",
   "type": "extract",
-  "expectedFeatures": ["a"],
+  "expectedFeatures": ["a", false],
   "inputRecord": {
     "leader": "02518cam a2200745zi 4500",
     "fields": [
-      {
-        "tag": "001",
-        "value": "000019643"
-      }
+      { "tag": "001", "value": "000019643" },
+      { "tag": "300", "ind1": " ", "ind2": " ", "subfields": [
+        {"code": "a", "value": "1 soitonopas (123 sivua)"}
+      ]}
     ]
   }
 }

--- a/test-fixtures/match-detection/features/bib/record-type/02/metadata.json
+++ b/test-fixtures/match-detection/features/bib/record-type/02/metadata.json
@@ -2,7 +2,7 @@
   "description": "Should extract record type (Empty leader)",
   "feature": "recordType",
   "type": "extract",
-  "expectedFeatures": [],
+  "expectedFeatures": [null, false],
   "inputRecord": {
     "leader": "",
     "fields": [

--- a/test-fixtures/match-detection/features/bib/record-type/05/metadata.json
+++ b/test-fixtures/match-detection/features/bib/record-type/05/metadata.json
@@ -1,0 +1,15 @@
+{
+  "description": "Should extract record type (LDR/06) and true for soitonopas",
+  "feature": "recordType",
+  "type": "extract",
+  "expectedFeatures": ["c", true],
+  "inputRecord": {
+    "leader": "02518ccm a2200745zi 4500",
+    "fields": [
+      { "tag": "001", "value": "000019643" },
+      { "tag": "300", "ind1": " ", "ind2": " ", "subfields": [
+        {"code": "a", "value": "1 soitonopas (123 sivua)"}
+      ]}
+    ]
+  }
+}

--- a/test-fixtures/match-detection/features/bib/title/c-06/metadata.json
+++ b/test-fixtures/match-detection/features/bib/title/c-06/metadata.json
@@ -5,5 +5,5 @@
   "expectedPoints": 0.5,
   "featuresA": ["songsofthespanishcivilwarvol1", "songsofthelincolnbrigadesixsongsfordemocracy", "", ""],
   "featuresB": ["songsofthespanishcivilwar", "songsofthelincolnbrigadesixsongsfordemocracy", "vol1", ""],
-  "only": true
+  "only": false
 }

--- a/test-fixtures/match-detection/features/bib/title/c-06/metadata.json
+++ b/test-fixtures/match-detection/features/bib/title/c-06/metadata.json
@@ -1,0 +1,9 @@
+{
+  "description": "MELKEHITYS-3494",
+  "feature": "title",
+  "type": "compare",
+  "expectedPoints": 0.5,
+  "featuresA": ["songsofthespanishcivilwarvol1", "songsofthelincolnbrigadesixsongsfordemocracy", "", ""],
+  "featuresB": ["songsofthespanishcivilwar", "songsofthelincolnbrigadesixsongsfordemocracy", "vol1", ""],
+  "only": true
+}

--- a/test-fixtures/match-detection/features/bib/title/c-07/metadata.json
+++ b/test-fixtures/match-detection/features/bib/title/c-07/metadata.json
@@ -6,5 +6,5 @@
   "expectedPoints": 0.25,
   "featuresA": ["soundsofwestafrica", "thecoraandthexylophone", "", ""],
   "featuresB": ["soundsofwestafrica", "thecoraandthexylophonemusicofthelobianddagartitribesofnorthernghanaandthegriotsofgambiaandsenegal", "", ""],
-  "only": true
+  "only": false
 }

--- a/test-fixtures/match-detection/features/bib/title/c-07/metadata.json
+++ b/test-fixtures/match-detection/features/bib/title/c-07/metadata.json
@@ -1,0 +1,10 @@
+{
+  "description": "MELKEHITYS-3498",
+  "feature": "title",
+  "comment": "shared part of $b aka [1] is removed and since A is $b-less we have a match...",
+  "type": "compare",
+  "expectedPoints": 0.25,
+  "featuresA": ["soundsofwestafrica", "thecoraandthexylophone", "", ""],
+  "featuresB": ["soundsofwestafrica", "thecoraandthexylophonemusicofthelobianddagartitribesofnorthernghanaandthegriotsofgambiaandsenegal", "", ""],
+  "only": true
+}

--- a/test-fixtures/match-detection/features/bib/title/c-08/metadata.json
+++ b/test-fixtures/match-detection/features/bib/title/c-08/metadata.json
@@ -6,5 +6,5 @@
   "expectedPoints": 0.25,
   "featuresA": ["soundsofwestafrica", "thecoraandthexylophone", "3", ""],
   "featuresB": ["soundsofwestafrica", "thecoraandthexylophonemusicofthelobianddagartitribesofnorthernghanaandthegriotsofgambiaandsenegal", "3", ""],
-  "only": true
+  "only": false
 }

--- a/test-fixtures/match-detection/features/bib/title/c-08/metadata.json
+++ b/test-fixtures/match-detection/features/bib/title/c-08/metadata.json
@@ -1,0 +1,10 @@
+{
+  "description": "MELKEHITYS-3498 plus shared $n",
+  "feature": "title",
+  "comment": "shared part of $b aka [1] is removed and since A is $b-less we have a match...",
+  "type": "compare",
+  "expectedPoints": 0.25,
+  "featuresA": ["soundsofwestafrica", "thecoraandthexylophone", "3", ""],
+  "featuresB": ["soundsofwestafrica", "thecoraandthexylophonemusicofthelobianddagartitribesofnorthernghanaandthegriotsofgambiaandsenegal", "3", ""],
+  "only": true
+}

--- a/test-fixtures/match-detection/features/bib/title/c-09/metadata.json
+++ b/test-fixtures/match-detection/features/bib/title/c-09/metadata.json
@@ -1,0 +1,10 @@
+{
+  "description": "features[2]: ignore non-numeric part if there's a matching number",
+  "feature": "title",
+  "comment": "shared part of $b aka [1] is removed and since A is $b-less we have a match...",
+  "type": "compare",
+  "expectedPoints": 0.5,
+  "featuresA": ["soundsofwestafrica", "", "volume3", ""],
+  "featuresB": ["soundsofwestafrica", "", "del3", ""],
+  "only": false
+}

--- a/test-fixtures/match-detection/features/bib/title/e-06/metadata.json
+++ b/test-fixtures/match-detection/features/bib/title/e-06/metadata.json
@@ -1,8 +1,8 @@
 {
-  "description": "Should extract titles with punctuation normalized away",
+  "description": "Should extract titles with most punctuation normalized away",
   "feature": "title",
   "type": "extract",
-  "expectedFeatures": ["foofaa", "bar", "", ""],
+  "expectedFeatures": ["foo&faa", "bar", "", ""],
   "inputRecord": {
     "leader": "02518cam a2200745zi 4500",
     "fields": [

--- a/test-fixtures/match-detection/features/bib/title/e-10/metadata.json
+++ b/test-fixtures/match-detection/features/bib/title/e-10/metadata.json
@@ -1,0 +1,31 @@
+{
+  "description": "Should extract titles ($a + $b)",
+  "comment": "Testing different subfield combinations",
+  "feature": "title",
+  "type": "extract",
+  "expectedFeatures": ["ultima", "", "4", "questoftheavatar"],
+  "inputRecord": {
+    "leader": "02518cam a2200745zi 4500",
+    "fields": [
+      { "tag": "001", "value": "000019643" },
+      { "tag": "245", "ind1": "1",
+        "ind2": " ",
+        "subfields": [
+          {
+            "code": "a",
+            "value": "Ultima."
+          },
+          {
+            "code": "n",
+            "value": "IV,"
+          },
+          {
+            "code": "p",
+            "value": "Quest of the Avatar."
+          }
+        ]
+      }
+    ]
+  },
+  "only": false
+}

--- a/test-fixtures/match-detection/features/bib/title/e-11/metadata.json
+++ b/test-fixtures/match-detection/features/bib/title/e-11/metadata.json
@@ -1,0 +1,22 @@
+{
+  "description": "MELKEHITYS-3496: check 245$a normalizations",
+  "feature": "title",
+  "type": "extract",
+  "expectedFeatures": ["songsofthewestvolume3geneautry&royrogers", "", "", ""],
+  "inputRecord": {
+    "leader": "02518cam a2200745zi 4500",
+    "fields": [
+      { "tag": "001", "value": "000019643" },
+      { "tag": "245", "ind1": "1",
+        "ind2": " ",
+        "subfields": [
+          {
+            "code": "a",
+            "value": "Songs of the West. Volume three : Gene Autry and Roy Rogers"
+          }
+        ]
+      }
+    ]
+  },
+  "only": false
+}


### PR DESCRIPTION
match-detection:  now does not outright reject book vs soitonopas. (It gives them score of 0.0 instead a small positive value that equal LDR/06 type of record pair would get.)

language: f041 scoring for mismatching have been altered. Generic scoring system was less than intuitive and was replaced with f041 specific rules. In general prnalties have also increased a bit, esp. if both records have languages that are not in the other...